### PR TITLE
Fix paths in build process for shared library builds on Windows

### DIFF
--- a/util/mk1mf.pl
+++ b/util/mk1mf.pl
@@ -340,9 +340,11 @@ $OPENSSLDIR =~ s|/|$o|g;
 # Build OQS
 if ($platform eq "VC-WIN32") {
 $vsplatform = "x86";
+$vsplatformdir = "Win32";
 }
 elsif (($platform eq "VC-WIN64A") || ($platform eq "VC-WIN64I"))  {
 $vsplatform = "x64";
+$vsplatformdir = "x64";
 }
 if ($debug = "1") {
 $vsconfig = "Debug";
@@ -501,7 +503,7 @@ EX_LIBS=$ex_libs
 SRC_D=$src_dir
 
 LINK_CMD=$link
-LFLAGS=$lflags /libpath:vendor${o}liboqs${o}VisualStudio${o}$vsplatform${o}$vsconfig
+LFLAGS=$lflags /libpath:vendor${o}liboqs${o}VisualStudio${o}$vsplatformdir${o}$vsconfig
 RSC=$rsc
 
 # The output directory for everything interesting

--- a/util/pl/VC-32.pl
+++ b/util/pl/VC-32.pl
@@ -208,6 +208,14 @@ $shlibp=($shlib)?".dll":".lib";
 $lfile='/out:';
 
 $shlib_ex_obj="";
+if ($FLAVOR =~ /WIN64A/) {
+  $shlib_ex_obj='vendor\\liboqs\\VisualStudio\\x64\\Debug\\oqs.lib';
+} elsif ($FLAVOR =~ /WIN32/) {
+  $shlib_ex_obj='vendor\\liboqs\\VisualStudio\\Win32\\Debug\\oqs.lib';
+} else {
+  print "Warning: Unsupported OQS flavor selected. Link step may not succeed!";
+}
+ 
 $app_ex_obj="setargv.obj" if ($FLAVOR !~ /CE/);
 if ($FLAVOR =~ /WIN64A/) {
 	if (`nasm -v 2>NUL` =~ /NASM version ([0-9]+\.[0-9]+)/ && $1 >= 2.0) {


### PR DESCRIPTION
Specifically reference the static oqs library when linking DLLs

Correctly reference the oqs output directory stemming from Visual
Studio referring to the platform as "x86" but calling the output
directory "Win32"