### PR TITLE
Updated OQS with ARM support

### DIFF
--- a/vendor/liboqs/README.md
+++ b/vendor/liboqs/README.md
@@ -41,7 +41,7 @@ Detailed information about each algorithm and implementations can be found in th
 Building and Running on Linux and macOS
 ---------------------------------------
 
-Builds have been tested on Mac OS X 10.11.6, macOS 10.12.5, Ubuntu 16.04.1.
+Builds have been tested on Mac OS X 10.10.5 (gcc/clang), Mac OS X 10.11.6 (clang), macOS 10.12.5 (clang), Ubuntu 16.04.1 (gcc).
 
 ### Install dependencies for macOS
 
@@ -204,13 +204,6 @@ Run it from your Android device:
 	adb shell "/data/local/tmp/test_kex"
 
 Tested on SM-930F
-
-Building for ARM
-----------------
-
-To build on ARM (such as a Raspberry Pi), certain ciphers must be disabled when running configure:
-
-	./configure --disable-aes-ni
 
 Building for Android
 --------------------

--- a/vendor/liboqs/configure.ac
+++ b/vendor/liboqs/configure.ac
@@ -88,7 +88,7 @@ DX_INIT_DOXYGEN([$PACKAGE_NAME],[doxygen.cfg])
 ######################################################################
 
 ARG_DISBL_SET([aes-ni], [enable AES-NI.])
-AM_CONDITIONAL([aes_ni], [test "x$aes_ni" = xtrue])
+AM_CONDITIONAL([aes_ni], [test "x$aes_ni" = xtrue]) # disabled on ARM below
 AM_CONDITIONAL([USE_AES_NI], [test "x$aes_ni" = xtrue])
 
 ARG_ENABL_SET([openssl], [enable OPENSSL.])
@@ -166,11 +166,18 @@ if test x"$linux" = x"true"; then
         AM_CPPFLAGS=${AM_CPPFLAGS}" -DSIDH_ASM -march=armv8-a+crc"
         arm64=true
         ;;
+    arm* )
+        AM_CPPFLAGS=${AM_CPPFLAGS}" -DARM"
+        AM_CONDITIONAL([aes_ni], [false])
+        AM_CONDITIONAL([USE_AES_NI], [false])
+        arm=true
+        ;;
   esac
 fi
 
 AM_CONDITIONAL([X86_64], [test "x$x86_64" = xtrue])
 AM_CONDITIONAL([ARM64], [test "x$arm64" = xtrue])
+AM_CONDITIONAL([ARM], [test "x$arm" = xtrue])
 
 # Common sources
 SRCDIR=" src/common"
@@ -231,7 +238,8 @@ fi
 
 # Flags
 AM_CPPFLAGS=${AM_CPPFLAGS}" -g -std=gnu11 -Wno-unused-function -Werror -Wpedantic -Wall -Wextra -DCONSTANT_TIME"
-if test x"$aes_ni" = x"true"; then
+# if test x"$aes_ni" = x"true" && test x"$ARM" = x"false"; then
+if test -z "${aes_ni_TRUE}"; then
   AM_CPPFLAGS=${AM_CPPFLAGS}" -DAES_ENABLE_NI"
 fi
 if test x"$openssl" = x"true"; then

--- a/vendor/liboqs/src/sig_picnic/Makefile.am
+++ b/vendor/liboqs/src/sig_picnic/Makefile.am
@@ -2,6 +2,9 @@ AUTOMAKE_OPTIONS = foreign
 noinst_LTLIBRARIES = libpicnic_i.la
 
 libpicnic_i_la_SOURCES = sig_picnic.c external/aligned_alloc.c external/bitstream.c external/cpu.c external/io.c external/kdf_shake.c external/lowmc.c external/lowmc_pars.c external/lowmc_128_128_20.c external/lowmc_192_192_30.c external/lowmc_256_256_38.c external/mpc.c external/mpc_lowmc.c external/mzd_additional.c external/picnic.c external/picnic_impl.c external/sha3/KeccakHash.c external/sha3/KeccakSponge.c external/sha3/opt64/KeccakP-1600-opt64.c
-libpicnic_i_la_CPPFLAGS = -I../../include -Iexternal -Iexternal/sha3 -Iexternal/sha3/opt64 -DMUL_M4RI -DREDUCED_LINEAR_LAYER -DHAVE_POSIX_MEMALIGN -DWITH_LOWMC_128_128_20 -DWITH_LOWMC_192_192_30 -DWITH_LOWMC_256_256_38 -DWITH_OPT -DWITH_SSE2 -DWITH_SSE4_1
+libpicnic_i_la_CPPFLAGS = -I../../include -Iexternal -Iexternal/sha3 -Iexternal/sha3/opt64 -DMUL_M4RI -DREDUCED_LINEAR_LAYER -DHAVE_POSIX_MEMALIGN -DWITH_LOWMC_128_128_20 -DWITH_LOWMC_192_192_30 -DWITH_LOWMC_256_256_38 -DWITH_OPT
+if !ARM
+libpicnic_i_la_CPPFLAGS += -DWITH_SSE2 -DWITH_SSE4_1
+endif
 libpicnic_i_la_CPPFLAGS += $(AM_CPPFLAGS) 
 


### PR DESCRIPTION
No more need to call OQS with special flags to build on ARM, so the OpenSSL build now also works on ARM directly.