### PR TITLE
Pass the compiler commands/flags to liboqs's Configure script

### DIFF
--- a/Makefile.org
+++ b/Makefile.org
@@ -279,7 +279,7 @@ build_all: build_libs build_apps build_tests build_tools
 build_libs: build_liboqs build_libcrypto build_libssl openssl.pc
 
 build_liboqs:
-	cd vendor/liboqs && autoreconf -i && ./configure --enable-shared && $(MAKE)
+	cd vendor/liboqs && autoreconf -i && CC="$(CC)" CFLAGS="$(CFLAG)" CCAS="$(AS)" CCASFLAGS="$(ASFLAG)" ./configure --enable-shared && $(MAKE)
 
 build_libcrypto: build_crypto build_engines libcrypto.pc
 build_libssl: build_ssl libssl.pc


### PR DESCRIPTION
OpenSSL's Makefile figures out what compiler and flags to use. Pass
those results to liboqs's Configure script.

At the very least this allows building the 32-bit version of OpenSSL on a 64-bit host. It might make it easier to use cross-compiling tools, although I haven't tried this.