### PR TITLE
Non-enabled OQS alg clarification and TODO

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This branch ([OQS-OpenSSL\_1\_1\_1-stable branch](https://github.com/open-quantu
 
 ### Key exchange mechanisms
 
-The following key exchange / key encapsulation mechanisms from liboqs are supported:
+The following key exchange / key encapsulation mechanisms from liboqs are supported (assuming they have been enabled in liboqs):
 
 - sike503, sike751
 - sidh503, sidh751

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -115,6 +115,8 @@ static int oqs_key_init(OQS_KEY **p_oqs_key, int nid, oqs_key_type_t keytype) {
     }
     oqs_key->s = OQS_SIG_new(oqs_alg_name);
     if (oqs_key->s == NULL) {
+      /* TODO: provide a better error message for non-enabled OQS schemes.
+	 Perhaps even check if the alg is available earlier in the stack. (FIXMEOQS) */
       OQSerr(0, ERR_R_FATAL);
       goto err;
     }

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -613,6 +613,8 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
 	const char* oqs_alg_name = OQS_ALG_NAME(oqs_nid);
 	/* initialize the kex */
 	if ((s->s3->tmp.oqs_kem = OQS_KEM_new(oqs_alg_name)) == NULL) {
+	  /* TODO: provide a better error message for non-enabled OQS schemes.
+	     Perhaps even check if the alg is available earlier in the stack. (FIXMEOQS) */
 	  SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_ADD_KEY_SHARE, ERR_R_INTERNAL_ERROR);
 	  has_error = 1;
 	  goto oqs_cleanup;

--- a/ssl/statem/extensions_srvr.c
+++ b/ssl/statem/extensions_srvr.c
@@ -1817,6 +1817,8 @@ EXT_RETURN tls_construct_stoc_key_share(SSL *s, WPACKET *pkt,
       const char* oqs_alg_name = OQS_ALG_NAME(oqs_nid);
       /* initialize the kex */
       if ((oqs_kem = OQS_KEM_new(oqs_alg_name)) == NULL) {
+	/* TODO: provide a better error message for non-enabled OQS schemes.
+	   Perhaps even check if the alg is available earlier in the stack. (FIXMEOQS) */
         SSLfatal(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_TLS_CONSTRUCT_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
 	has_error = 1;


### PR DESCRIPTION
Added TODO and clarification in README for supported but non-enabled OQS alg.