### PR TITLE
Add support for OQS nist branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ More information on OQS can be found on our website: [https://openquantumsafe.or
 open-quantum-safe/openssl branch OQS-OpenSSL\_1\_1\_1-stable
 ------------------------------------------------------------
 
+TODO: document support for nist-branch (FIXMEOQS)
+
 This branch ([OQS-OpenSSL\_1\_1\_1-stable branch](https://github.com/open-quantum-safe/openssl/tree/OQS-OpenSSL_1_1_1-stable)) integrates post-quantum key exchange from liboqs in TLS 1.3 in OpenSSL v1.1.1.  
 
 (For TLS 1.2, see the [OQS-OpenSSL\_1\_0\_2-stable](https://github.com/open-quantum-safe/openssl/tree/OQS-OpenSSL_1_0_2-stable) branch.)

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -20,6 +20,7 @@
 #ifndef OPENSSL_NO_DH
 # include <openssl/dh.h>
 #endif
+#include <oqs/config.h>
 #include "s_apps.h"
 
 #define COOKIE_SECRET_LENGTH    16
@@ -243,7 +244,8 @@ static const char *get_sigtype(int nid)
      case NID_id_GostR3410_2012_512:
         return "gost2012_512";
 
-     /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+     /* OQS sig schemes */
      case NID_picnicL1FS:
         return "Picnic L1 FS";
      case NID_qTESLA_I:
@@ -253,7 +255,7 @@ static const char *get_sigtype(int nid)
      case NID_qTESLA_III_speed:
         return "qTESLA-III-speed";
      /* ADD_MORE_OQS_SIG_HERE */
-
+#endif
     default:
         return NULL;
     }

--- a/crypto/asn1/standard_methods.h
+++ b/crypto/asn1/standard_methods.h
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <oqs/config.h>
+
 /*
  * This table MUST be kept in ascending order of the NID each method
  * represents (corresponding to the pkey_id field) as OBJ_bsearch
@@ -57,11 +59,13 @@ static const EVP_PKEY_ASN1_METHOD *standard_methods[] = {
 #ifndef OPENSSL_NO_SM2
     &sm2_asn1_meth,
 #endif
-    /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes */
     &picnicL1FS_asn1_meth,
     &qteslaI_asn1_meth,
     &qteslaIIIsize_asn1_meth,
     &qteslaIIIspeed_asn1_meth,
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
 };
 

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -17,6 +17,10 @@
 #include <oqs/rand.h>
 #include <oqs/common.h>
 #include <oqs/sig.h>
+#include <oqs/config.h>
+
+/* Only supports OQS's master branch signature API for now */
+#if !defined(OQS_NIST_BRANCH)
 
 /*
  * OQS context
@@ -528,7 +532,7 @@ static int pkey_oqs_digestverify(EVP_MD_CTX *ctx, const unsigned char *sig,
       OQSerr(0, ERR_R_FATAL);
       return 0;
     }
-
+ ADD_MORE_OQS_SIG_HERE
     return 1;
 }
 
@@ -570,3 +574,5 @@ DEFINE_OQS_EVP_METHODS(picnicL1FS, NID_picnicL1FS, "picnicL1FS", "OpenSSL Picnic
 DEFINE_OQS_EVP_METHODS(qteslaI, NID_qTESLA_I, "qteslaI", "OpenSSL qTESLA-I algorithm")
 DEFINE_OQS_EVP_METHODS(qteslaIIIsize, NID_qTESLA_III_size, "qteslaIIIsize", "OpenSSL qTESLA-III-size algorithm")
 DEFINE_OQS_EVP_METHODS(qteslaIIIspeed, NID_qTESLA_III_speed, "qteslaIIIspeed", "OpenSSL qTESLA-III-speed algorithm")
+
+#endif /* OQS_MASTER */

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -532,7 +532,7 @@ static int pkey_oqs_digestverify(EVP_MD_CTX *ctx, const unsigned char *sig,
       OQSerr(0, ERR_R_FATAL);
       return 0;
     }
- ADD_MORE_OQS_SIG_HERE
+
     return 1;
 }
 

--- a/crypto/evp/pmeth_lib.c
+++ b/crypto/evp/pmeth_lib.c
@@ -13,6 +13,7 @@
 #include <openssl/engine.h>
 #include <openssl/evp.h>
 #include <openssl/x509v3.h>
+#include <oqs/config.h>
 #include "internal/asn1_int.h"
 #include "internal/evp_int.h"
 #include "internal/numbers.h"
@@ -67,12 +68,14 @@ static const EVP_PKEY_METHOD *standard_methods[] = {
 #ifndef OPENSSL_NO_SM2
     &sm2_pkey_meth,
 #endif
-    /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes */
     &picnicL1FS_pkey_meth,
     &qteslaI_pkey_meth,
     &qteslaIIIsize_pkey_meth,
     &qteslaIIIspeed_pkey_meth,
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
 };
 
 DECLARE_OBJ_BSEARCH_CMP_FN(const EVP_PKEY_METHOD *, const EVP_PKEY_METHOD *,

--- a/crypto/include/internal/asn1_int.h
+++ b/crypto/include/internal/asn1_int.h
@@ -9,6 +9,8 @@
 
 /* Internal ASN1 structures and functions: not for application use */
 
+#include <oqs/config.h>
+
 /* ASN1 public key method structure */
 
 struct evp_pkey_asn1_method_st {
@@ -84,12 +86,14 @@ extern const EVP_PKEY_ASN1_METHOD rsa_asn1_meths[2];
 extern const EVP_PKEY_ASN1_METHOD rsa_pss_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD siphash_asn1_meth;
 
-/* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+/* OQS sig schemes */
 extern const EVP_PKEY_ASN1_METHOD picnicL1FS_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD qteslaI_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD qteslaIIIsize_asn1_meth;
 extern const EVP_PKEY_ASN1_METHOD qteslaIIIspeed_asn1_meth;
 /* ADD_MORE_OQS_SIG_HERE */
+#endif
 
 /*
  * These are used internally in the ASN1_OBJECT to keep track of whether the

--- a/crypto/include/internal/evp_int.h
+++ b/crypto/include/internal/evp_int.h
@@ -8,6 +8,7 @@
  */
 
 #include <openssl/evp.h>
+#include <oqs/config.h>
 #include "internal/refcount.h"
 
 /*
@@ -111,12 +112,14 @@ extern const EVP_PKEY_METHOD tls1_prf_pkey_meth;
 extern const EVP_PKEY_METHOD hkdf_pkey_meth;
 extern const EVP_PKEY_METHOD poly1305_pkey_meth;
 extern const EVP_PKEY_METHOD siphash_pkey_meth;
-/* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+/* OQS sig schemes */
 extern const EVP_PKEY_METHOD picnicL1FS_pkey_meth;
 extern const EVP_PKEY_METHOD qteslaI_pkey_meth;
 extern const EVP_PKEY_METHOD qteslaIIIsize_pkey_meth;
 extern const EVP_PKEY_METHOD qteslaIIIspeed_pkey_meth;
 /* ADD_MORE_OQS_SIG_HERE */
+#endif
 
 struct evp_md_st {
     int type;

--- a/crypto/x509/x509type.c
+++ b/crypto/x509/x509type.c
@@ -12,6 +12,7 @@
 #include <openssl/evp.h>
 #include <openssl/objects.h>
 #include <openssl/x509.h>
+#include <oqs/config.h>
 
 int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
 {
@@ -46,12 +47,14 @@ int X509_certificate_type(const X509 *x, const EVP_PKEY *pkey)
         break;
     case EVP_PKEY_ED448:
     case EVP_PKEY_ED25519:
-    /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes */
     case EVP_PKEY_PICNICL1FS:
     case EVP_PKEY_QTESLAI:
     case EVP_PKEY_QTESLAIIISIZE:
     case EVP_PKEY_QTESLAIIISPEED:
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
         ret = EVP_PKT_SIGN;
         break;
     case EVP_PKEY_DH:

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -15,6 +15,7 @@
 # include <openssl/symhacks.h>
 # include <openssl/bio.h>
 # include <openssl/evperr.h>
+# include <oqs/config.h>
 
 # define EVP_MAX_MD_SIZE                 64/* longest known is SHA512 */
 # define EVP_MAX_KEY_LENGTH              64
@@ -62,12 +63,14 @@
 # define EVP_PKEY_ED25519 NID_ED25519
 # define EVP_PKEY_X448 NID_X448
 # define EVP_PKEY_ED448 NID_ED448
-/* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+/* OQS sig schemes */
 # define EVP_PKEY_PICNICL1FS NID_picnicL1FS
 # define EVP_PKEY_QTESLAI NID_qTESLA_I
 # define EVP_PKEY_QTESLAIIISIZE NID_qTESLA_III_size
 # define EVP_PKEY_QTESLAIIISPEED NID_qTESLA_III_speed
 /* ADD_MORE_OQS_SIG_HERE */
+#endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/ssl/ssl_cert_table.h
+++ b/ssl/ssl_cert_table.h
@@ -7,6 +7,8 @@
  * https://www.openssl.org/source/license.html
  */
 
+#include <oqs/config.h>
+
 /*
  * Certificate table information. NB: table entries must match SSL_PKEY indices
  */
@@ -20,10 +22,12 @@ static const SSL_CERT_LOOKUP ssl_cert_info [] = {
     {NID_id_GostR3410_2012_512, SSL_aGOST12}, /* SSL_PKEY_GOST12_512 */
     {EVP_PKEY_ED25519, SSL_aECDSA}, /* SSL_PKEY_ED25519 */
     {EVP_PKEY_ED448, SSL_aECDSA}, /* SSL_PKEY_ED448 */
-    /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes */
     {EVP_PKEY_PICNICL1FS, SSL_aPICNICL1FS}, /* SSL_PKEY_PICNICL1FS */
     {EVP_PKEY_QTESLAI, SSL_aQTESLAI}, /* SSL_PKEY_QTESLAI */
     {EVP_PKEY_QTESLAIIISIZE, SSL_aQTESLAIIISIZE}, /* SSL_PKEY_QTESLAIIISIZE */
     {EVP_PKEY_QTESLAIIISPEED, SSL_aQTESLAIIISPEED} /* SSL_PKEY_QTESLAIIISPEED */
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
 };

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -202,7 +202,8 @@
 # define SSL_aSRP                0x00000040U
 /* GOST R 34.10-2012 signature auth */
 # define SSL_aGOST12             0x00000080U
-/* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+/* OQS sig schemes */
 /* Picnic */
 # define SSL_aPICNICL1FS         0x00000100U
 /* qTESLA */
@@ -210,6 +211,7 @@
 # define SSL_aQTESLAIIISIZE      0x00000400U
 # define SSL_aQTESLAIIISPEED     0x00000800U
 /* ADD_MORE_OQS_SIG_HERE */
+#endif
 /* Any appropriate signature auth (for TLS 1.3 ciphersuites) */
 # define SSL_aANY                0x00000000U
 /* All bits requiring a certificate */
@@ -392,13 +394,17 @@
 # define SSL_PKEY_GOST12_512     6
 # define SSL_PKEY_ED25519        7
 # define SSL_PKEY_ED448          8
-/* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+/* OQS sig schemes */
 # define SSL_PKEY_PICNICL1FS     9
 # define SSL_PKEY_QTESLAI        10
 # define SSL_PKEY_QTESLAIIISIZE  11
 # define SSL_PKEY_QTESLAIIISPEED 12
 /* ADD_MORE_OQS_SIG_HERE */
 # define SSL_PKEY_NUM            13
+#else
+# define SSL_PKEY_NUM            9
+#endif
 /*
  * Pseudo-constant. GOST cipher suites can use different certs for 1
  * SSL_CIPHER. So let's see which one we have in fact.
@@ -426,8 +432,10 @@
 #define NID_OQS_START            2000
 #define NID_OQS_SIKE_503         (NID_OQS_START + 0)
 #define NID_OQS_SIKE_751         (NID_OQS_START + 1)
+#if !defined(OQS_NIST_BRANCH)
 #define NID_OQS_SIDH_503         (NID_OQS_START + 2)
 #define NID_OQS_SIDH_751         (NID_OQS_START + 3)
+#endif
 #define NID_OQS_Frodo_640_AES    (NID_OQS_START + 4)
 #define NID_OQS_Frodo_640_cshake (NID_OQS_START + 5)
 #define NID_OQS_Frodo_976_AES    (NID_OQS_START + 6)
@@ -448,7 +456,9 @@
 
 #define NID_HYBRID_START              (NID_OQS_END + 1)
 #define NID_OQS_p256_SIKE_503         (NID_HYBRID_START + 0)
+#if !defined(OQS_NIST_BRANCH)
 #define NID_OQS_p256_SIDH_503         (NID_HYBRID_START + 1)
+#endif
 #define NID_OQS_p256_Frodo_640_AES    (NID_HYBRID_START + 2)
 #define NID_OQS_p256_Frodo_640_cshake (NID_HYBRID_START + 3)
 #define NID_OQS_p256_BIKE1_L1         (NID_HYBRID_START + 4)
@@ -464,61 +474,92 @@
 #define IS_OQS_KEM_NID(nid) (nid >= NID_OQS_START && nid <= NID_OQS_END)
 
 /* Returns the curve ID for an OQS KEM NID */
-#define OQS_KEM_CURVEID(nid) (nid == NID_OQS_SIKE_503         ? 0x0200 : \
-			     (nid == NID_OQS_SIKE_751         ? 0x0201 : \
-			     (nid == NID_OQS_SIDH_503         ? 0x0202 : \
-			     (nid == NID_OQS_SIDH_751         ? 0x0203 : \
-			     (nid == NID_OQS_Frodo_640_AES    ? 0x0204 : \
-			     (nid == NID_OQS_Frodo_640_cshake ? 0x0205 : \
-			     (nid == NID_OQS_Frodo_976_AES    ? 0x0206 : \
-			     (nid == NID_OQS_Frodo_976_cshake ? 0x0207 : \
-			     (nid == NID_OQS_BIKE1_L1         ? 0x0208 : \
-			     (nid == NID_OQS_BIKE1_L3         ? 0x0209 : \
-			     (nid == NID_OQS_BIKE1_L5         ? 0x020a : \
-			     (nid == NID_OQS_BIKE2_L1         ? 0x020b : \
-			     (nid == NID_OQS_BIKE2_L3         ? 0x020c : \
-			     (nid == NID_OQS_BIKE2_L5         ? 0x020d : \
-			     (nid == NID_OQS_BIKE3_L1         ? 0x020e : \
-			     (nid == NID_OQS_BIKE3_L3         ? 0x020f : \
-			     (nid == NID_OQS_BIKE3_L5         ? 0x0210 : \
-			     (nid == NID_OQS_NEWHOPE_512_CCA  ? 0x0211 : \
-			     (nid == NID_OQS_NEWHOPE_1024_CCA ? 0x0212 : \
-			     /* ADD_MORE_OQS_KEM_HERE */ \
-			      0)))))))))))))))))))
+static int OQS_KEM_CURVEID(int nid) {
+  int rv;
+  switch (nid) {
+  case NID_OQS_SIKE_503 : rv = 0x0200; break;
+  case NID_OQS_SIKE_751 : rv = 0x0201; break;
+#if !defined(OQS_NIST_BRANCH)
+  case NID_OQS_SIDH_503 : rv = 0x0202; break;
+  case NID_OQS_SIDH_751 : rv = 0x0203; break;
+#endif
+  case NID_OQS_Frodo_640_AES : rv = 0x0204; break;
+  case NID_OQS_Frodo_640_cshake : rv = 0x0205; break;
+  case NID_OQS_Frodo_976_AES : rv = 0x0206; break;
+  case NID_OQS_Frodo_976_cshake : rv = 0x0207; break;
+  case NID_OQS_BIKE1_L1 : rv = 0x0208; break;
+  case NID_OQS_BIKE1_L3 : rv = 0x0209; break;
+  case NID_OQS_BIKE1_L5 : rv = 0x020a; break;
+  case NID_OQS_BIKE2_L1 : rv = 0x020b; break;
+  case NID_OQS_BIKE2_L3 : rv = 0x020c; break;
+  case NID_OQS_BIKE2_L5 : rv = 0x020d; break;
+  case NID_OQS_BIKE3_L1 : rv = 0x020e; break;
+  case NID_OQS_BIKE3_L3 : rv = 0x020f; break;
+  case NID_OQS_BIKE3_L5 : rv = 0x0210; break;
+  case NID_OQS_NEWHOPE_512_CCA  : rv = 0x0211; break;
+  case NID_OQS_NEWHOPE_1024_CCA : rv = 0x0212; break;
+  /* ADD_MORE_OQS_KEM_HERE */
+  default: rv = 0;
+  }
+  return rv;
+}
 
-#define OQS_KEM_HYBRID_CURVEID(nid) (nid == NID_OQS_p256_SIKE_503         ? 0x0300 : \
-				    (nid == NID_OQS_p256_SIDH_503         ? 0x0301 : \
-				    (nid == NID_OQS_p256_Frodo_640_AES    ? 0x0302 : \
-				    (nid == NID_OQS_p256_Frodo_640_cshake ? 0x0303 : \
-				    (nid == NID_OQS_p256_BIKE1_L1         ? 0x0304 : \
-				    (nid == NID_OQS_p256_BIKE2_L1         ? 0x0305 : \
-				    (nid == NID_OQS_p256_BIKE3_L1         ? 0x0306 : \
-				    (nid == NID_OQS_p256_NEWHOPE_512_CCA  ? 0x0307 : \
-				    /* ADD_MORE_OQS_KEM_HERE (L1 schemes) */ \
-			            0))))))))
+static int OQS_KEM_HYBRID_CURVEID(int nid) {
+  int rv;
+  switch (nid) {
+  case NID_OQS_p256_SIKE_503         : rv = 0x0300; break;
+#if !defined(OQS_NIST_BRANCH)
+  case NID_OQS_p256_SIDH_503         : rv = 0x0301; break;
+#endif
+  case NID_OQS_p256_Frodo_640_AES    : rv = 0x0302; break;
+  case NID_OQS_p256_Frodo_640_cshake : rv = 0x0303; break;
+  case NID_OQS_p256_BIKE1_L1         : rv = 0x0304; break;
+  case NID_OQS_p256_BIKE2_L1         : rv = 0x0305; break;
+  case NID_OQS_p256_BIKE3_L1         : rv = 0x0306; break;
+  case NID_OQS_p256_NEWHOPE_512_CCA  : rv = 0x0307; break;
+  /* ADD_MORE_OQS_KEM_HERE (L1 schemes) */
+  default: rv = 0;
+  }
+  return rv;
+}
 
-#define OQS_KEM_NID(curveID)  ((curveID == 0x0200 || curveID == 0x0300) ? NID_OQS_SIKE_503 : \
-			      ( curveID == 0x0201                       ? NID_OQS_SIKE_751 : \
-			      ((curveID == 0x0202 || curveID == 0x0300) ? NID_OQS_SIDH_503 : \
-			      ( curveID == 0x0203                       ? NID_OQS_SIDH_751 : \
-			      ((curveID == 0x0204 || curveID == 0x0302) ? NID_OQS_Frodo_640_AES : \
-			      ((curveID == 0x0205 || curveID == 0x0303) ? NID_OQS_Frodo_640_cshake : \
-			      ( curveID == 0x0206                       ? NID_OQS_Frodo_976_AES : \
-			      ( curveID == 0x0207                       ? NID_OQS_Frodo_976_cshake : \
-			      ((curveID == 0x0208 || curveID == 0x0304) ? NID_OQS_BIKE1_L1 : \
-			      ( curveID == 0x0209                       ? NID_OQS_BIKE1_L3 : \
-			      ( curveID == 0x020a                       ? NID_OQS_BIKE1_L5 : \
-			      ((curveID == 0x020b || curveID == 0x0305) ? NID_OQS_BIKE2_L1 : \
-			      ( curveID == 0x020c                       ? NID_OQS_BIKE2_L3 : \
-			      ( curveID == 0x020d                       ? NID_OQS_BIKE2_L5 : \
-			      ((curveID == 0x020e || curveID == 0x0306) ? NID_OQS_BIKE3_L1 : \
-			      ( curveID == 0x020f                       ? NID_OQS_BIKE3_L3 : \
-			      ( curveID == 0x0210                       ? NID_OQS_BIKE3_L5 : \
-			      ( curveID == 0x0211 || curveID == 0x0307) ? NID_OQS_NEWHOPE_512_CCA : \
-			      ( curveID == 0x0212                       ? NID_OQS_NEWHOPE_1024_CCA : \
-			      /* ADD_MORE_OQS_KEM_HERE */ \
-			      0 ))))))))))))))))))
-
+static int OQS_KEM_NID(int curveID) {
+  int rv;
+  switch (curveID) {
+  case 0x0200:
+  case 0x0300: rv = NID_OQS_SIKE_503; break;
+  case 0x0201: rv = NID_OQS_SIKE_751; break;
+#if !defined(OQS_NIST_BRANCH)
+  case 0x0202:
+  case 0x0300: rv = NID_OQS_SIDH_503; break;
+  case 0x0203: rv = NID_OQS_SIDH_751; break;
+#endif
+  case 0x0204:
+  case 0x0302: rv = NID_OQS_Frodo_640_AES; break;
+  case 0x0205:
+  case 0x0303: rv = NID_OQS_Frodo_640_cshake; break;
+  case 0x0206: rv = NID_OQS_Frodo_976_AES; break;
+  case 0x0207: rv = NID_OQS_Frodo_976_cshake; break;
+  case 0x0208:
+  case 0x0304: rv = NID_OQS_BIKE1_L1; break;
+  case 0x0209: rv = NID_OQS_BIKE1_L3; break;
+  case 0x020a: rv = NID_OQS_BIKE1_L5; break;
+  case 0x020b:
+  case 0x0305: rv = NID_OQS_BIKE2_L1; break;
+  case 0x020c: rv = NID_OQS_BIKE2_L3; break;
+  case 0x020d: rv = NID_OQS_BIKE2_L5; break;
+  case 0x020e:
+  case 0x0306: rv = NID_OQS_BIKE3_L1; break;
+  case 0x020f: rv = NID_OQS_BIKE3_L3; break;
+  case 0x0210: rv = NID_OQS_BIKE3_L5; break;
+  case 0x0211:
+  case 0x0307: rv = NID_OQS_NEWHOPE_512_CCA; break;
+  case 0x0212: rv = NID_OQS_NEWHOPE_1024_CCA; break;
+  /* ADD_MORE_OQS_KEM_HERE */
+  default: rv = 0;
+  }
+  return rv;
+}
 
 /* Returns true if the curve ID is for an OQS KEX */
 #define IS_OQS_KEM_CURVEID(id) (id >= 0x0200 && id <= 0x0212) /* ADD_MORE_OQS_KEM_HERE (update)*/
@@ -527,27 +568,33 @@
 #define IS_OQS_KEM_HYBRID_CURVEID(id) (id >= 0x0300 && id <= 0x0307) /* ADD_MORE_OQS_KEM_HERE (L1 schemes, update) */
 
 /* Returns the OQS alg ID for OQS API */
-#define OQS_ALG_NAME(nid)    (nid == NID_OQS_SIKE_503         ? OQS_KEM_alg_sike_p503 : \
-			     (nid == NID_OQS_SIKE_751         ? OQS_KEM_alg_sike_p751 : \
-			     (nid == NID_OQS_SIDH_503         ? OQS_KEM_alg_sidh_p503 : \
-			     (nid == NID_OQS_SIDH_751         ? OQS_KEM_alg_sidh_p751 : \
-			     (nid == NID_OQS_Frodo_640_AES    ? OQS_KEM_alg_frodokem_640_aes : \
-			     (nid == NID_OQS_Frodo_640_cshake ? OQS_KEM_alg_frodokem_640_cshake : \
-			     (nid == NID_OQS_Frodo_976_AES    ? OQS_KEM_alg_frodokem_976_aes : \
-			     (nid == NID_OQS_Frodo_976_cshake ? OQS_KEM_alg_frodokem_976_cshake : \
-			     (nid == NID_OQS_BIKE1_L1         ? OQS_KEM_alg_bike1_l1 : \
-			     (nid == NID_OQS_BIKE1_L3         ? OQS_KEM_alg_bike1_l3 : \
-			     (nid == NID_OQS_BIKE1_L5         ? OQS_KEM_alg_bike1_l5 : \
-			     (nid == NID_OQS_BIKE2_L1         ? OQS_KEM_alg_bike2_l1 : \
-			     (nid == NID_OQS_BIKE2_L3         ? OQS_KEM_alg_bike2_l3 : \
-			     (nid == NID_OQS_BIKE2_L5         ? OQS_KEM_alg_bike2_l5 : \
-			     (nid == NID_OQS_BIKE3_L1         ? OQS_KEM_alg_bike3_l1 : \
-			     (nid == NID_OQS_BIKE3_L3         ? OQS_KEM_alg_bike3_l3: \
-			     (nid == NID_OQS_BIKE3_L5         ? OQS_KEM_alg_bike3_l5 : \
-			     (nid == NID_OQS_NEWHOPE_512_CCA  ? OQS_KEM_alg_newhope_512_cca_kem : \
-			     (nid == NID_OQS_NEWHOPE_1024_CCA ? OQS_KEM_alg_newhope_1024_cca_kem : \
-			     /* ADD_MORE_OQS_KEM_HERE */ \
-			      "")))))))))))))))))))
+static const char* OQS_ALG_NAME(int nid) {
+  switch(nid){
+  case NID_OQS_SIKE_503        : return OQS_KEM_alg_sike_p503;
+  case NID_OQS_SIKE_751        : return OQS_KEM_alg_sike_p751;
+#if !defined(OQS_NIST_BRANCH)
+  case NID_OQS_SIDH_503        : return OQS_KEM_alg_sidh_p503;
+  case NID_OQS_SIDH_751        : return OQS_KEM_alg_sidh_p751;
+#endif
+  case NID_OQS_Frodo_640_AES   : return OQS_KEM_alg_frodokem_640_aes;
+  case NID_OQS_Frodo_640_cshake: return OQS_KEM_alg_frodokem_640_cshake;
+  case NID_OQS_Frodo_976_AES   : return OQS_KEM_alg_frodokem_976_aes;
+  case NID_OQS_Frodo_976_cshake: return OQS_KEM_alg_frodokem_976_cshake;
+  case NID_OQS_BIKE1_L1        : return OQS_KEM_alg_bike1_l1;
+  case NID_OQS_BIKE1_L3        : return OQS_KEM_alg_bike1_l3;
+  case NID_OQS_BIKE1_L5        : return OQS_KEM_alg_bike1_l5;
+  case NID_OQS_BIKE2_L1        : return OQS_KEM_alg_bike2_l1;
+  case NID_OQS_BIKE2_L3        : return OQS_KEM_alg_bike2_l3;
+  case NID_OQS_BIKE2_L5        : return OQS_KEM_alg_bike2_l5;
+  case NID_OQS_BIKE3_L1        : return OQS_KEM_alg_bike3_l1;
+  case NID_OQS_BIKE3_L3        : return OQS_KEM_alg_bike3_l3;
+  case NID_OQS_BIKE3_L5        : return  OQS_KEM_alg_bike3_l5;
+  case NID_OQS_NEWHOPE_512_CCA : return OQS_KEM_alg_newhope_512_cca_kem;
+  case NID_OQS_NEWHOPE_1024_CCA: return OQS_KEM_alg_newhope_1024_cca_kem;
+   /* ADD_MORE_OQS_KEM_HERE */
+  default: return "";
+  }
+}
 
 /* Returns the classical nid for an hybrid alg (FIXMEOQS: only secp256r1 (23) is supported for now) */
 #define OQS_KEM_CLASSICAL_CURVEID(curveID) (IS_OQS_KEM_HYBRID_CURVEID(curveID) ? 23 : 0)
@@ -2191,12 +2238,14 @@ typedef enum downgrade_en {
 #define TLSEXT_SIGALG_ed25519                                   0x0807
 #define TLSEXT_SIGALG_ed448                                     0x0808
 
-/* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+/* OQS sig schemes */
 #define TLSEXT_SIGALG_picnicL1FS                                0xfe00 /* private use code point */
 #define TLSEXT_SIGALG_qteslaI                                   0xfe01 /* private use code point */
 #define TLSEXT_SIGALG_qteslaIIIsize                             0xfe02 /* private use code point */
 #define TLSEXT_SIGALG_qteslaIIIspeed                            0xfe03 /* private use code point */
 /* ADD_MORE_OQS_SIG_HERE */
+#endif
 
 /* Known PSK key exchange modes */
 #define TLSEXT_KEX_MODE_KE                                      0x00

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -531,7 +531,7 @@ static int OQS_KEM_NID(int curveID) {
   case 0x0201: rv = NID_OQS_SIKE_751; break;
 #if !defined(OQS_NIST_BRANCH)
   case 0x0202:
-  case 0x0300: rv = NID_OQS_SIDH_503; break;
+  case 0x0301: rv = NID_OQS_SIDH_503; break;
   case 0x0203: rv = NID_OQS_SIDH_751; break;
 #endif
   case 0x0204:

--- a/ssl/ssl_oqs_extra.h
+++ b/ssl/ssl_oqs_extra.h
@@ -8,10 +8,12 @@ static int OQS_nid_from_string(const char *value) {
     nid = NID_OQS_SIKE_503;
   } else if (memcmp(value,"sike751", len) == 0) {
     nid = NID_OQS_SIKE_751;
+#if !defined(OQS_NIST_BRANCH)
   } else if (memcmp(value,"sidh503", len) == 0) {
     nid = NID_OQS_SIDH_503;
   } else if (memcmp(value,"sidh751", len) == 0) {
     nid = NID_OQS_SIDH_751;
+#endif
   } else if (memcmp(value,"frodo640aes", len) == 0) {
     nid = NID_OQS_Frodo_640_AES;
   } else if (memcmp(value,"frodo640cshake", len) == 0) {
@@ -46,8 +48,10 @@ static int OQS_nid_from_string(const char *value) {
   /* hybrid algs */
   } else if (memcmp(value,"p256-sike503", len) == 0) {
     nid = NID_OQS_p256_SIKE_503;
+#if !defined(OQS_NIST_BRANCH)
   } else if (memcmp(value,"p256-sidh503", len) == 0) {
     nid = NID_OQS_p256_SIDH_503;
+#endif
   } else if (memcmp(value,"p256-frodo640aes", len) == 0) {
     nid = NID_OQS_p256_Frodo_640_AES;
   } else if (memcmp(value,"p256-frodo640cshake", len) == 0) {

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -20,6 +20,7 @@
 #include "internal/nelem.h"
 #include "ssl_locl.h"
 #include <openssl/ct.h>
+#include <oqs/config.h>
 #include "ssl_oqs_extra.h"
 
 SSL3_ENC_METHOD const TLSv1_enc_data = {
@@ -175,8 +176,10 @@ static const TLS_GROUP_INFO nid_list[] = {
 static const TLS_GROUP_INFO oqs_nid_list[] = {
     {NID_OQS_SIKE_503, 128, TLS_CURVE_CUSTOM}, /* sike503 (0x0200) */
     {NID_OQS_SIKE_751, 192, TLS_CURVE_CUSTOM}, /* sike751 (0x0201) */
+#if !defined(OQS_NIST_BRANCH)
     {NID_OQS_SIDH_503, 128, TLS_CURVE_CUSTOM}, /* sidh503 (0x0202) */
     {NID_OQS_SIDH_751, 192, TLS_CURVE_CUSTOM}, /* sidh751 (0x0203) */
+#endif
     {NID_OQS_Frodo_640_AES, 128, TLS_CURVE_CUSTOM}, /* frodo640aes (0x0204) */
     {NID_OQS_Frodo_640_cshake, 128, TLS_CURVE_CUSTOM}, /* frodo640cshake (0x0205) */
     {NID_OQS_Frodo_976_AES, 192, TLS_CURVE_CUSTOM}, /* frodo976aes (0x0206) */
@@ -197,7 +200,9 @@ static const TLS_GROUP_INFO oqs_nid_list[] = {
     /* Hybrid OQS groups. Security level is classical. */
 static const TLS_GROUP_INFO oqs_hybrid_nid_list[] = {
     {NID_OQS_p256_SIKE_503, 128, TLS_CURVE_CUSTOM}, /* p256 + sike503 hybrid (0x0300) */
+#if !defined(OQS_NIST_BRANCH)
     {NID_OQS_p256_SIDH_503, 128, TLS_CURVE_CUSTOM}, /* p256 + sidh503 hybrid (0x0301) */
+#endif
     {NID_OQS_p256_Frodo_640_AES, 128, TLS_CURVE_CUSTOM}, /* p256 + frodo640aes hybrid (0x0302) */
     {NID_OQS_p256_Frodo_640_cshake, 128, TLS_CURVE_CUSTOM}, /* p256 + frodo640cshake hybrid (0x0303) */
     {NID_OQS_p256_BIKE1_L1, 128, TLS_CURVE_CUSTOM}, /* p256 + bike1l1 hybrid (0x0304) */
@@ -224,8 +229,10 @@ static const uint16_t eccurves_default[] = {
        Also, shouldn't be in the default list; need to be added to s->ext.supportedgroups */
     0x0200, /* OQS sike503 */
     0x0201, /* OQS sike751 */
+#if !defined(OQS_NIST_BRANCH)
     0x0202, /* OQS sidh503 */
     0x0203, /* OQS sidh751 */
+#endif
     0x0204, /* OQS frodo640aes */
     0x0205, /* OQS frodo640cshake */
     0x0206, /* OQS frodo976aes */
@@ -243,7 +250,9 @@ static const uint16_t eccurves_default[] = {
     0x0212, /* OQS newhope1024cca */
     /* ADD_MORE_OQS_KEM_HERE */
     0x0300, /* p256 - OQS sike503 hybrid */
+#if !defined(OQS_NIST_BRANCH)
     0x0301, /* p256 - OQS sidh503 hybrid */
+#endif
     0x0302, /* p256 - OQS frodo640aes hybrid */
     0x0303, /* p256 - OQS frodo640cshake hybrid */
     0x0304, /* p256 - OQS bike1l1 hybrid */
@@ -730,12 +739,14 @@ static const uint16_t tls12_sigalgs[] = {
     TLSEXT_SIGALG_ed25519,
     TLSEXT_SIGALG_ed448,
 #endif
-    /* OQS schemes*/
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes*/
     TLSEXT_SIGALG_picnicL1FS,
     TLSEXT_SIGALG_qteslaI,
     TLSEXT_SIGALG_qteslaIIIsize,
     TLSEXT_SIGALG_qteslaIIIspeed,
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
 
     TLSEXT_SIGALG_rsa_pss_pss_sha256,
     TLSEXT_SIGALG_rsa_pss_pss_sha384,
@@ -864,7 +875,8 @@ static const SIGALG_LOOKUP sigalg_lookup_tbl[] = {
      NID_id_GostR3410_2001, SSL_PKEY_GOST01,
      NID_undef, NID_undef},
 #endif
-    /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes */
     {"picnicL1FS", TLSEXT_SIGALG_picnicL1FS,
      NID_undef, -1, EVP_PKEY_PICNICL1FS, SSL_PKEY_PICNICL1FS,
      NID_undef, NID_undef},
@@ -878,6 +890,7 @@ static const SIGALG_LOOKUP sigalg_lookup_tbl[] = {
      NID_undef, -1, EVP_PKEY_QTESLAIIISPEED, SSL_PKEY_QTESLAIIISPEED,
      NID_undef, NID_undef},
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
 };
 /* Legacy sigalgs for TLS < 1.2 RSA TLS signatures */
 static const SIGALG_LOOKUP legacy_rsa_sigalg = {
@@ -2440,12 +2453,14 @@ void tls1_set_cert_validity(SSL *s)
     tls1_check_chain(s, NULL, NULL, NULL, SSL_PKEY_GOST12_512);
     tls1_check_chain(s, NULL, NULL, NULL, SSL_PKEY_ED25519);
     tls1_check_chain(s, NULL, NULL, NULL, SSL_PKEY_ED448);
-    /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes */
     tls1_check_chain(s, NULL, NULL, NULL, SSL_PKEY_PICNICL1FS);
     tls1_check_chain(s, NULL, NULL, NULL, SSL_PKEY_QTESLAI);
     tls1_check_chain(s, NULL, NULL, NULL, SSL_PKEY_QTESLAIIISIZE);
     tls1_check_chain(s, NULL, NULL, NULL, SSL_PKEY_QTESLAIIISPEED);
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
 }
 
 /* User level utility function to check a chain is suitable */

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -603,12 +603,14 @@ static const ssl_trace_tbl ssl_sigalg_tbl[] = {
     {TLSEXT_SIGALG_gostr34102012_256_gostr34112012_256, "gost2012_256"},
     {TLSEXT_SIGALG_gostr34102012_512_gostr34112012_512, "gost2012_512"},
     {TLSEXT_SIGALG_gostr34102001_gostr3411, "gost2001_gost94"},
-    /* OQS schemes */
+#if !defined(OQS_NIST_BRANCH)
+    /* OQS sig schemes */
     {TLSEXT_SIGALG_picnicL1FS, "picnicL1FS"},
     {TLSEXT_SIGALG_qteslaI, "qteslaI"},
     {TLSEXT_SIGALG_qteslaIIIsize, "qteslaIIIsize"},
     {TLSEXT_SIGALG_qteslaIIIspeed, "qteslaIIIspeed"},
     /* ADD_MORE_OQS_SIG_HERE */
+#endif
 };
 
 static const ssl_trace_tbl ssl_ctype_tbl[] = {


### PR DESCRIPTION
*NOT READY FOR MERGE*: this is the proposed strategy to enable using the nist-branch for TLS 1.3.

Enabled the use of OQS's nist-branch in OpenSSL 1.1.1. The OpenSSL code uses the OQS_NIST_BRANCH macro, defined in OQS's config.h, to disable the signature support and the use of SIDH.

TODO:
 - update the readme to document support and limitation of nist-branch
 - check that windows build is not affected
 - re-test the code with the oqs master branch
