### PR TITLE
Disable references to SIDH, which apparently isn't in the NIST branch

### DIFF
--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -533,8 +533,10 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
     {OQS_KEM_CURVEID(NID_OQS_KEM_DEFAULT), "OQS KEM default"},
     {OQS_KEM_CURVEID(NID_OQS_SIKE_503), "sike503"},
     {OQS_KEM_CURVEID(NID_OQS_SIKE_751), "sike503"},
+#ifndef OQS_NIST_BRANCH
     {OQS_KEM_CURVEID(NID_OQS_SIDH_503), "sidh503"},
     {OQS_KEM_CURVEID(NID_OQS_SIDH_751), "sidh751"},
+#endif
     {OQS_KEM_CURVEID(NID_OQS_Frodo_640_AES), "frodo640aes"},
     {OQS_KEM_CURVEID(NID_OQS_Frodo_640_cshake), "frodo640cshake"},
     {OQS_KEM_CURVEID(NID_OQS_Frodo_976_AES), "frodo976aes"},
@@ -590,9 +592,11 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
     */
 #endif
     /* ADD_MORE_OQS_KEM_HERE */
-    {OQS_KEM_CURVEID(NID_OQS_p256_OQS_KEM_DEFAULT), "p256 - OQS KEM default hybrid"},
+    {OQS_KEM_CURVEID(NID_OQS_p256_KEM_DEFAULT), "p256 - OQS KEM default hybrid"},
     {OQS_KEM_CURVEID(NID_OQS_p256_SIKE_503), "p256 - sike503 hybrid"},
+#ifndef OQS_NIST_BRANCH
     {OQS_KEM_CURVEID(NID_OQS_p256_SIDH_503), "p256 - sidh503 hybrid"},
+#endif
     {OQS_KEM_CURVEID(NID_OQS_p256_Frodo_640_AES), "p256 - frodo640aes hybrid"},
     {OQS_KEM_CURVEID(NID_OQS_p256_Frodo_640_cshake), "p256 - frodo640cshake hybrid"},
     {OQS_KEM_CURVEID(NID_OQS_p256_BIKE1_L1), "p256 - bike1l1 hybrid"},


### PR DESCRIPTION
Also fixes a typo in `_DEFAULT`