### PR TITLE
Re-enabled the Windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Next, you must download and build liboqs using the master branch of liboqs (the 
 
 ### Step 3: Build fork of OpenSSL
 
-Now we follow the standard instructions for building OpenSSL, for example
+Now we follow the standard instructions for building OpenSSL:
 
     cd ..\openssl
     perl Configure VC-WIN64A

--- a/README.md
+++ b/README.md
@@ -132,6 +132,39 @@ For **macOS**:
     
 The OQS fork of OpenSSL can also be built with shared libraries, but we have used `no-shared` in the instructions above to avoid having to get the shared libraries in the right place for the runtime linker.
 
+Building on Windows
+-------------------
+
+Builds have been tested on Windows 10 (VS2017 build tools). Make sure you can build the unmodified version of OpenSSL by following the instructions in [INSTALL.W64](https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/INSTALL.W64).
+
+### Step 1: Download fork of OpenSSL
+
+Clone or download the source from Github:
+
+    git clone --branch OQS-OpenSSL_1_0_2-stable https://github.com/open-quantum-safe/openssl.git
+
+### Step 2: Build liboqs
+
+Next, you must download and build liboqs using the master branch of liboqs (the nist branch is not currently supported on Windows).  The following instructions will download and build that branch of liboqs, then copy the required files it into a subdirectory inside the OpenSSL folder.  You may need to install dependencies before building liboqs; see the [liboqs master branch README.md](https://github.com/open-quantum-safe/liboqs/blob/master/README.md).
+
+    git clone --branch master https://github.com/open-quantum-safe/liboqs.git
+    cd liboqs
+    msbuild VisualStudio\liboqs.sln
+    mkdir ..\openssl\oqs
+    mkdir ..\openssl\oqs\lib
+    mkdir ..\openssl\oqs\include
+    xcopy VisualStudio\x64\Release\oqs.lib ..\openssl\oqs\lib\
+    xcopy /S VisualStudio\include ..\openssl\oqs\include\
+
+### Step 3: Build fork of OpenSSL
+
+Now we follow the standard instructions for building OpenSSL, for example
+
+    cd ..\openssl
+    perl Configure VC-WIN64A
+    ms\do_win64a
+    nmake -f ms\nt.mak
+
 Running
 -------
 

--- a/util/mk1mf.pl
+++ b/util/mk1mf.pl
@@ -496,6 +496,7 @@ TMP_D=$tmp_dir
 # The output directory for the header files
 INC_D=$inc_dir
 INCO_D=$inc_dir${o}openssl
+INCOQS_D=$inc_dir${o}oqs
 
 PERL=$perl
 CP=$cp
@@ -518,6 +519,9 @@ O_FIPSCANISTER=\$(FIPSLIB_D)${o}fipscanister.lib
 FIPS_SHA1_EXE=\$(FIPSDIR)${o}bin${o}fips_standalone_sha1${exep}
 PREMAIN_DSO_EXE=\$(BIN_D)${o}fips_premain_dso$exep
 FIPSLINK=\$(PERL) \$(FIPSDIR)${o}bin${o}fipslink.pl
+
+# OQS headers
+LIBOQS_INCLUDE = oqs${o}include${o}oqs
 
 ######################################################
 # You should not need to touch anything below this point
@@ -551,7 +555,7 @@ SO_CRYPTO= $plib\$(CRYPTO)$so_shlibp
 L_SSL=     \$(LIB_D)$o$plib\$(SSL)$libp
 L_CRYPTO=  \$(LIB_D)$o$plib\$(CRYPTO)$libp
 
-L_LIBS= \$(L_SSL) \$(L_CRYPTO) $ex_l_libs
+L_LIBS= \$(L_SSL) \$(L_CRYPTO) oqs${o}lib${o}oqs.lib $ex_l_libs
 
 ######################################################
 # Don't touch anything below this point
@@ -567,10 +571,14 @@ LIBS_DEP=\$(O_CRYPTO) \$(O_SSL)
 EOF
 
 $rules=<<"EOF";
-all: banner \$(TMP_D) \$(BIN_D) \$(TEST_D) \$(LIB_D) \$(INCO_D) headers lib exe $build_targets
+all: banner incoqs \$(TMP_D) \$(BIN_D) \$(TEST_D) \$(LIB_D) \$(INCO_D) headers lib exe $build_targets
 
 banner:
 $banner
+
+incoqs:
+	\$(MKDIR) \"\$(INCOQS_D)\"
+        \$(CP) \"\$(LIBOQS_INCLUDE)${o}*.h" \"\$(INCOQS_D)\"
 
 \$(TMP_D):
 	\$(MKDIR) \"\$(TMP_D)\"
@@ -606,8 +614,10 @@ install: all
 	\$(MKDIR) \"\$(INSTALLTOP)${o}bin\"
 	\$(MKDIR) \"\$(INSTALLTOP)${o}include\"
 	\$(MKDIR) \"\$(INSTALLTOP)${o}include${o}openssl\"
+	\$(MKDIR) \"\$(INSTALLTOP)${o}include${o}oqs\"
 	\$(MKDIR) \"\$(INSTALLTOP)${o}lib\"
 	\$(CP) \"\$(INCO_D)${o}*.\[ch\]\" \"\$(INSTALLTOP)${o}include${o}openssl\"
+	\$(CP) \"\$(INCOQS_D)${o}*.\[ch\]\" \"\$(INSTALLTOP)${o}include${o}oqs\"
 	\$(CP) \"\$(BIN_D)$o\$(E_EXE)$exep\" \"\$(INSTALLTOP)${o}bin\"
 	\$(MKDIR) \"\$(OPENSSLDIR)\"
 	\$(CP) apps${o}openssl.cnf \"\$(OPENSSLDIR)\"


### PR DESCRIPTION
The Windows build had been disabled after the removal of OQS as a submodule, and never was re-enabled on this branch. This PR makes it possible to build on Windows again, adding the instructions to the README.md and updating the build files.