### PR TITLE
Replace tabs by spaces in spaces-indented files

### DIFF
--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -117,7 +117,7 @@ static int oqs_key_init(OQS_KEY **p_oqs_key, int nid, oqs_key_type_t keytype) {
     oqs_key->s = OQS_SIG_new(oqs_alg_name);
     if (oqs_key->s == NULL) {
       /* TODO: provide a better error message for non-enabled OQS schemes.
-	 Perhaps even check if the alg is available earlier in the stack. (FIXMEOQS) */
+         Perhaps even check if the alg is available earlier in the stack. (FIXMEOQS) */
       OQSerr(0, ERR_R_FATAL);
       goto err;
     }
@@ -130,8 +130,8 @@ static int oqs_key_init(OQS_KEY **p_oqs_key, int nid, oqs_key_type_t keytype) {
     if (keytype == KEY_TYPE_PRIVATE) {
       oqs_key->privkey = OPENSSL_secure_malloc(oqs_key->s->length_secret_key);
       if (oqs_key->privkey == NULL) {
-	OQSerr(0, ERR_R_MALLOC_FAILURE);
-	goto err;
+        OQSerr(0, ERR_R_MALLOC_FAILURE);
+        goto err;
       }
     }
     oqs_key->security_bits = get_oqs_security_bits(nid);
@@ -180,7 +180,7 @@ static int oqs_pub_decode(EVP_PKEY *pkey, X509_PUBKEY *pubkey)
     }
     if (p == NULL) {
       /* pklen is checked below, after we instantiate the oqs_key to
-	 learn the expected len */
+         learn the expected len */
       OQSerr(0, ERR_R_FATAL);
       return 0;
     }
@@ -191,8 +191,8 @@ static int oqs_pub_decode(EVP_PKEY *pkey, X509_PUBKEY *pubkey)
       /* Algorithm parameters must be absent */
       X509_ALGOR_get0(NULL, &ptype, NULL, palg);
       if (ptype != V_ASN1_UNDEF) {
-	OQSerr(0, ERR_R_FATAL);
-	return 0;
+        OQSerr(0, ERR_R_FATAL);
+        return 0;
       }
     }
 
@@ -248,8 +248,8 @@ static int oqs_priv_decode(EVP_PKEY *pkey, const PKCS8_PRIV_KEY_INFO *p8)
       /* Algorithm parameters must be absent */
       X509_ALGOR_get0(NULL, &ptype, NULL, palg);
       if (ptype != V_ASN1_UNDEF) {
-	OQSerr(0, ERR_R_FATAL);
-	return 0;
+        OQSerr(0, ERR_R_FATAL);
+        return 0;
       }
     }
 
@@ -398,12 +398,12 @@ static int oqs_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
     X509_ALGOR_get0(&obj, &ptype, NULL, sigalg);
     nid = OBJ_obj2nid(obj);
     if (
-	(nid != NID_picnicL1FS &&
-	 nid != NID_qTESLA_I &&
-	 nid != NID_qTESLA_III_size &&
-	 nid != NID_qTESLA_III_speed
-	 /* ADD_MORE_OQS_SIG_HERE */
-	 ) || ptype != V_ASN1_UNDEF) {
+        (nid != NID_picnicL1FS &&
+         nid != NID_qTESLA_I &&
+         nid != NID_qTESLA_III_size &&
+         nid != NID_qTESLA_III_speed
+         /* ADD_MORE_OQS_SIG_HERE */
+         ) || ptype != V_ASN1_UNDEF) {
         OQSerr(0, ERR_R_FATAL);
         return 0;
     }

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3731,12 +3731,12 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
 #endif
     case SSL_CTRL_GET_OQS_KEM_CURVE_ID:
         {
-	  if (s->server || s->session == NULL || s->s3->tmp.oqs_kem_curve_id == 0) {
-	    return 0;
-	  } else {
+          if (s->server || s->session == NULL || s->s3->tmp.oqs_kem_curve_id == 0) {
+            return 0;
+          } else {
             return s->s3->tmp.oqs_kem_curve_id;
-	  }
-	}
+          }
+        }
     default:
         break;
     }

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -566,7 +566,7 @@
 #else
 #define OQS_KEM_CURVEID_NIST_BRANCH(nid) \
   /* schemes only in master branch */ \
-  (nid == NID_OQS_SIDH_503 ? 0x0202 :	\
+  (nid == NID_OQS_SIDH_503 ? 0x0202 :   \
   (nid == NID_OQS_SIDH_751 ? 0x0203 : \
    0))
 #endif
@@ -598,13 +598,13 @@
 #define OQS_KEM_HYBRID_CURVEID_NIST_BRANCH(nid) \
   /* schemes only in nist branch */ \
   /* some schemes are disabled because their keys/ciphertext are too big for TLS */ \
-  /* (nid == NID_OQS_p256_bigquake1       ? 0x0308 : */	\
+  /* (nid == NID_OQS_p256_bigquake1       ? 0x0308 : */ \
   (nid == NID_OQS_p256_kyber512         ? 0x0309 : \
   (nid == NID_OQS_p256_ledakem_C1_N02   ? 0x030a : \
   (nid == NID_OQS_p256_ledakem_C1_N03   ? 0x030b : \
   (nid == NID_OQS_p256_ledakem_C1_N04   ? 0x030c : \
   /* (nid == NID_OQS_p256_lima_sp_1018_cca ? 0x030d : */ \
-  /* (nid == NID_OQS_p256_saber_light_saber ? 0x030e :	*/ \
+  /* (nid == NID_OQS_p256_saber_light_saber ? 0x030e :  */ \
   /* (nid == NID_OQS_p256_titanium_cca_std ? 0x030f : */ \
   /* (nid == NID_OQS_p256_titanium_cca_med ? 0x0310 : */ \
    0))))
@@ -652,14 +652,14 @@
   (curveID == 0x0224 /* || curveID == 0x030d */ ? NID_OQS_lima_sp_1018_cca : \
   (curveID == 0x0225 ? NID_OQS_lima_sp_1306_cca : \
   (curveID == 0x0226 ? NID_OQS_lima_sp_1822_cca : \
-  /* (curveID == 0x0227 ? NID_OQS_lima_sp_2062_cca : */		\
+  /* (curveID == 0x0227 ? NID_OQS_lima_sp_2062_cca : */         \
   (curveID == 0x0228 /* || (curveID == 0x030e: */ ? NID_OQS_saber_light_saber : \
   (curveID == 0x0229 ? NID_OQS_saber_saber : \
   (curveID == 0x022a ? NID_OQS_saber_fire_saber : \
    /* (curveID == 0x022b || curveID == 0x030f ? NID_OQS_titanium_cca_std : */ \
    /* (curveID == 0x022c ? NID_OQS_titanium_cca_hi : */ \
    /* (curveID == 0x022d || curveID == 0x0310 ? NID_OQS_titanium_cca_med : */ \
-   /* (curveID == 0x022e ? NID_OQS_titanium_cca_super :	*/ \
+   /* (curveID == 0x022e ? NID_OQS_titanium_cca_super : */ \
    0 ))))))))))))))))))
 #else
 #define OQS_KEM_NID_NIST_BRANCH(curveID) \
@@ -2001,8 +2001,8 @@ typedef struct ssl3_state_st {
         int min_ver;
         int max_ver;
         /*
-	 * OQS artefacts.
-	 */
+         * OQS artefacts.
+         */
         int oqs_kem_curve_id; /* curve_id of the kex */
         OQS_KEM* oqs_kem; /* KEM context */
         int oqs_peer_msg_len; /* save peer message's len */

--- a/ssl/statem/ext_oqs_extra.h
+++ b/ssl/statem/ext_oqs_extra.h
@@ -2,20 +2,20 @@
 
 #define ENCODE_UINT32(pbuf, i)  (pbuf)[index]   = (unsigned char)((i>>24) & 0xff); \
                                 (pbuf)[index+1] = (unsigned char)((i>>16) & 0xff); \
-				(pbuf)[index+2] = (unsigned char)((i>> 8) & 0xff); \
-				(pbuf)[index+3] = (unsigned char)((i    ) & 0xff)
+                                (pbuf)[index+2] = (unsigned char)((i>> 8) & 0xff); \
+                                (pbuf)[index+3] = (unsigned char)((i    ) & 0xff)
 #define DECODE_UINT32(i, pbuf)  i  = ((uint32_t) (pbuf)[index])   << 24; \
                                 i |= ((uint32_t) (pbuf)[index+1]) << 16; \
-				i |= ((uint32_t) (pbuf)[index+2]) <<  8; \
-				i |= ((uint32_t) (pbuf)[index+3])
+                                i |= ((uint32_t) (pbuf)[index+2]) <<  8; \
+                                i |= ((uint32_t) (pbuf)[index+3])
 
 /* Encodes two messages (classical and PQC) into one hybrid message:
    msg1_len || msg1 || msg2_len || msg2
    hybrid_msg is allocated in this function.
  */
 static int OQS_encode_hybrid_message(const unsigned char* msg1, uint32_t  msg1_len,
-				     const unsigned char* msg2, uint32_t  msg2_len,
-				     unsigned char** hybrid_msg, uint32_t* hybrid_msg_len) {
+                                     const unsigned char* msg2, uint32_t  msg2_len,
+                                     unsigned char** hybrid_msg, uint32_t* hybrid_msg_len) {
   int index = 0;
   *hybrid_msg_len = msg1_len + msg2_len + (2 * sizeof(uint32_t));
   *hybrid_msg = OPENSSL_malloc(*hybrid_msg_len);
@@ -40,8 +40,8 @@ static int OQS_encode_hybrid_message(const unsigned char* msg1, uint32_t  msg1_l
    msg1 and msg2 are allocated in this function.
  */
 static int OQS_decode_hybrid_message(const unsigned char* hybrid_msg,
-				     unsigned char** msg1, uint32_t* msg1_len,
-				     unsigned char** msg2, uint32_t* msg2_len) {
+                                     unsigned char** msg1, uint32_t* msg1_len,
+                                     unsigned char** msg2, uint32_t* msg2_len) {
   int index = 0;
   DECODE_UINT32(*msg1_len, hybrid_msg);
   index += sizeof(uint32_t);

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -610,41 +610,41 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
         key_share_key = s->s3->tmp.pkey;
     } else {
       if (do_pqc || do_hybrid) {
-	/* This is a group handled by OQS */
-	int has_error = 0;
-	int oqs_nid = OQS_KEM_NID(curve_id);
-	const char* oqs_alg_name = OQS_ALG_NAME(oqs_nid);
-	/* initialize the kex */
-	if ((s->s3->tmp.oqs_kem = OQS_KEM_new(oqs_alg_name)) == NULL) {
-	  /* TODO: provide a better error message for non-enabled OQS schemes.
-	     Perhaps even check if the alg is available earlier in the stack. (FIXMEOQS) */
-	  SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_ADD_KEY_SHARE, ERR_R_INTERNAL_ERROR);
-	  has_error = 1;
-	  goto oqs_cleanup;
-	}
-	/* compute the client's key and first message (encoded in encoded_point) */
-	if ((oqs_encoded_point = malloc(s->s3->tmp.oqs_kem->length_public_key)) == NULL ||
-	    (s->s3->tmp.oqs_kem_client = malloc(s->s3->tmp.oqs_kem->length_secret_key)) == NULL ||
-	    OQS_KEM_keypair(s->s3->tmp.oqs_kem, oqs_encoded_point, s->s3->tmp.oqs_kem_client) != OQS_SUCCESS) {
-	  SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_ADD_KEY_SHARE, ERR_R_INTERNAL_ERROR);
-	  has_error = 1;
-	  goto oqs_cleanup;
-	}
-	oqs_encodedlen = s->s3->tmp.oqs_kem->length_public_key;
+        /* This is a group handled by OQS */
+        int has_error = 0;
+        int oqs_nid = OQS_KEM_NID(curve_id);
+        const char* oqs_alg_name = OQS_ALG_NAME(oqs_nid);
+        /* initialize the kex */
+        if ((s->s3->tmp.oqs_kem = OQS_KEM_new(oqs_alg_name)) == NULL) {
+          /* TODO: provide a better error message for non-enabled OQS schemes.
+             Perhaps even check if the alg is available earlier in the stack. (FIXMEOQS) */
+          SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_ADD_KEY_SHARE, ERR_R_INTERNAL_ERROR);
+          has_error = 1;
+          goto oqs_cleanup;
+        }
+        /* compute the client's key and first message (encoded in encoded_point) */
+        if ((oqs_encoded_point = malloc(s->s3->tmp.oqs_kem->length_public_key)) == NULL ||
+            (s->s3->tmp.oqs_kem_client = malloc(s->s3->tmp.oqs_kem->length_secret_key)) == NULL ||
+            OQS_KEM_keypair(s->s3->tmp.oqs_kem, oqs_encoded_point, s->s3->tmp.oqs_kem_client) != OQS_SUCCESS) {
+          SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_ADD_KEY_SHARE, ERR_R_INTERNAL_ERROR);
+          has_error = 1;
+          goto oqs_cleanup;
+        }
+        oqs_encodedlen = s->s3->tmp.oqs_kem->length_public_key;
 
       oqs_cleanup:
-	if (has_error) {
-	  OQS_MEM_secure_free(s->s3->tmp.oqs_kem_client, s->s3->tmp.oqs_kem->length_secret_key);
-	  OQS_MEM_insecure_free(oqs_encoded_point);
-	  s->s3->tmp.oqs_kem_client = NULL;
-	  OQS_KEM_free(s->s3->tmp.oqs_kem);
-	  s->s3->tmp.oqs_kem = NULL;
-	  return 0;
-	}
+        if (has_error) {
+          OQS_MEM_secure_free(s->s3->tmp.oqs_kem_client, s->s3->tmp.oqs_kem->length_secret_key);
+          OQS_MEM_insecure_free(oqs_encoded_point);
+          s->s3->tmp.oqs_kem_client = NULL;
+          OQS_KEM_free(s->s3->tmp.oqs_kem);
+          s->s3->tmp.oqs_kem = NULL;
+          return 0;
+        }
       }
       if (!do_pqc) {
-	/* get the curve_id for the classical alg */
-	int classical_curve_id = do_hybrid ? OQS_KEM_CLASSICAL_CURVEID(curve_id) : curve_id;
+        /* get the curve_id for the classical alg */
+        int classical_curve_id = do_hybrid ? OQS_KEM_CLASSICAL_CURVEID(curve_id) : curve_id;
         key_share_key = ssl_generate_pkey_group(s, classical_curve_id);
         if (key_share_key == NULL) {
             /* SSLfatal() already called */
@@ -665,7 +665,7 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
     if (do_hybrid) {
       uint32_t encodedlen32;
       if (!OQS_encode_hybrid_message(classical_encoded_point, classical_encodedlen, oqs_encoded_point, oqs_encodedlen, &encoded_point, &encodedlen32)) {
-	goto err;
+        goto err;
       }
       encodedlen = encodedlen32;
       OPENSSL_free(classical_encoded_point);
@@ -1938,8 +1938,8 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
     /* parse the encoded_pt, which is either a classical, PQC, or hybrid (both) message. */
     if (do_hybrid) {
       if (!OQS_decode_hybrid_message(PACKET_data(&encoded_pt), &classical_encoded_pt, &classical_encodedlen, &oqs_encoded_pt, &oqs_encodedlen)) {
-	has_error = 1;
-	goto oqs_cleanup;
+        has_error = 1;
+        goto oqs_cleanup;
       }
     } else if (do_pqc) {
       oqs_encoded_pt = (unsigned char*) PACKET_data(&encoded_pt);
@@ -1954,94 +1954,94 @@ int tls_parse_stoc_key_share(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
       if (skey == NULL) {
         SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE,
                  ERR_R_MALLOC_FAILURE);
-	has_error = 1;
-	goto oqs_cleanup;
+        has_error = 1;
+        goto oqs_cleanup;
       }
       if (!EVP_PKEY_set1_tls_encodedpoint(skey, classical_encoded_pt, classical_encodedlen)) {
         SSLfatal(s, SSL_AD_ILLEGAL_PARAMETER, SSL_F_TLS_PARSE_STOC_KEY_SHARE,
                  SSL_R_BAD_ECPOINT);
         EVP_PKEY_free(skey);
-	has_error = 1;
-	goto oqs_cleanup;
+        has_error = 1;
+        goto oqs_cleanup;
       }
       /* OQS note: only derive the secret if we don't do hybrid. In case of hybrid, the
-	 shared key will be store in s->s3->tmp.pms */
+         shared key will be store in s->s3->tmp.pms */
       if (ssl_derive(s, ckey, skey, do_hybrid ? 0 : 1) == 0) {
         /* SSLfatal() already called */
         EVP_PKEY_free(skey);
-	has_error = 1;
-	goto oqs_cleanup;
+        has_error = 1;
+        goto oqs_cleanup;
       }
     }
     if (do_pqc || do_hybrid) {
-	/* make sure ctx and key were initialized in add_key_share */
-	if (s->s3->tmp.oqs_kem == NULL || s->s3->tmp.oqs_kem_client == NULL) {
-	  /* this should never happen */
-	  has_error = 1;
-	  goto oqs_cleanup;
-	}
-	/* compute the shared secret */
-	if ((oqs_shared_secret = malloc(s->s3->tmp.oqs_kem->length_shared_secret)) == NULL ||
-	    OQS_KEM_decaps(s->s3->tmp.oqs_kem, oqs_shared_secret, oqs_encoded_pt, s->s3->tmp.oqs_kem_client) != OQS_SUCCESS) {
-	  SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
-	  has_error = 1;
-	  goto oqs_cleanup;
-	}
-	oqs_shared_secret_len = s->s3->tmp.oqs_kem->length_shared_secret;
-	/* We save the group_id so it can be printed out later in s_client's output. */
-	s->s3->tmp.oqs_kem_curve_id = group_id;
+        /* make sure ctx and key were initialized in add_key_share */
+        if (s->s3->tmp.oqs_kem == NULL || s->s3->tmp.oqs_kem_client == NULL) {
+          /* this should never happen */
+          has_error = 1;
+          goto oqs_cleanup;
+        }
+        /* compute the shared secret */
+        if ((oqs_shared_secret = malloc(s->s3->tmp.oqs_kem->length_shared_secret)) == NULL ||
+            OQS_KEM_decaps(s->s3->tmp.oqs_kem, oqs_shared_secret, oqs_encoded_pt, s->s3->tmp.oqs_kem_client) != OQS_SUCCESS) {
+          SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
+          has_error = 1;
+          goto oqs_cleanup;
+        }
+        oqs_shared_secret_len = s->s3->tmp.oqs_kem->length_shared_secret;
+        /* We save the group_id so it can be printed out later in s_client's output. */
+        s->s3->tmp.oqs_kem_curve_id = group_id;
 
-	/* derive the ssl secret */
-	if (do_hybrid) {
-	  /* make sure the classical secret was correctly generated above */
-	  if (s->s3->tmp.pmslen == 0 ||  s->s3->tmp.pms == NULL) {
-	    SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
-	    has_error = 1;
-	    goto oqs_cleanup;
-	  }
-	  /* we concatenate the classical and oqs shared secret */
-	  shared_secret_len = s->s3->tmp.pmslen + oqs_shared_secret_len;
-	  shared_secret = OPENSSL_malloc(shared_secret_len);
-	  memcpy(shared_secret, s->s3->tmp.pms, s->s3->tmp.pmslen);
-	  memcpy(shared_secret + s->s3->tmp.pmslen, oqs_shared_secret, oqs_shared_secret_len);
-	} else {
-	  /* we use the oqs shared secret */
-	  shared_secret_len = oqs_shared_secret_len;
-	  shared_secret = oqs_shared_secret;
-	}
+        /* derive the ssl secret */
+        if (do_hybrid) {
+          /* make sure the classical secret was correctly generated above */
+          if (s->s3->tmp.pmslen == 0 ||  s->s3->tmp.pms == NULL) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
+            has_error = 1;
+            goto oqs_cleanup;
+          }
+          /* we concatenate the classical and oqs shared secret */
+          shared_secret_len = s->s3->tmp.pmslen + oqs_shared_secret_len;
+          shared_secret = OPENSSL_malloc(shared_secret_len);
+          memcpy(shared_secret, s->s3->tmp.pms, s->s3->tmp.pmslen);
+          memcpy(shared_secret + s->s3->tmp.pmslen, oqs_shared_secret, oqs_shared_secret_len);
+        } else {
+          /* we use the oqs shared secret */
+          shared_secret_len = oqs_shared_secret_len;
+          shared_secret = oqs_shared_secret;
+        }
 
-	{
-	  /* this code, copied from ssl_derive, updates the session secret */
-	  if (!s->hit) {
-	    if (!tls13_generate_secret(s, ssl_handshake_md(s), NULL, NULL, 0, (unsigned char *)&s->early_secret)) {
-	      SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
-	      has_error = 1;
-	      goto oqs_cleanup;
-	    }
-	  }
-	  if (!tls13_generate_handshake_secret(s, shared_secret, shared_secret_len)) {
-	    SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
-	    has_error = 1;
-	    goto oqs_cleanup;
-	  }
-	}
+        {
+          /* this code, copied from ssl_derive, updates the session secret */
+          if (!s->hit) {
+            if (!tls13_generate_secret(s, ssl_handshake_md(s), NULL, NULL, 0, (unsigned char *)&s->early_secret)) {
+              SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
+              has_error = 1;
+              goto oqs_cleanup;
+            }
+          }
+          if (!tls13_generate_handshake_secret(s, shared_secret, shared_secret_len)) {
+            SSLfatal(s, SSL_AD_INTERNAL_ERROR, SSL_F_TLS_PARSE_STOC_KEY_SHARE, ERR_R_INTERNAL_ERROR);
+            has_error = 1;
+            goto oqs_cleanup;
+          }
+        }
 
     oqs_cleanup:
-	/* we free the OQS artefacts on success or error */
-	OQS_MEM_secure_free(shared_secret, shared_secret_len);
-	OQS_MEM_secure_free(s->s3->tmp.oqs_kem_client, s->s3->tmp.oqs_kem->length_secret_key);
-	s->s3->tmp.oqs_kem_client = NULL;
-	OQS_KEM_free(s->s3->tmp.oqs_kem);
-	s->s3->tmp.oqs_kem = NULL;
-	if (do_hybrid) {
-	/* we allocated these in the hybrid case. in the non-hybrid case, these are
-	   just pointers into the packet, and openssl will clean them up */
-	  OPENSSL_free(classical_encoded_pt);
-	  OPENSSL_free(oqs_encoded_pt);
-	}
-	if (has_error) {
-	  return 0;
-	}
+        /* we free the OQS artefacts on success or error */
+        OQS_MEM_secure_free(shared_secret, shared_secret_len);
+        OQS_MEM_secure_free(s->s3->tmp.oqs_kem_client, s->s3->tmp.oqs_kem->length_secret_key);
+        s->s3->tmp.oqs_kem_client = NULL;
+        OQS_KEM_free(s->s3->tmp.oqs_kem);
+        s->s3->tmp.oqs_kem = NULL;
+        if (do_hybrid) {
+        /* we allocated these in the hybrid case. in the non-hybrid case, these are
+           just pointers into the packet, and openssl will clean them up */
+          OPENSSL_free(classical_encoded_pt);
+          OPENSSL_free(oqs_encoded_pt);
+        }
+        if (has_error) {
+          return 0;
+        }
     }
 
     s->s3->peer_tmp = skey;

--- a/ssl/statem/statem_clnt.c
+++ b/ssl/statem/statem_clnt.c
@@ -987,7 +987,7 @@ size_t ossl_statem_client_max_message_size(SSL *s)
        * longer PQC signatures. (See https://github.com/openssl/openssl/issues/6433)
        */
       /* return SSL3_RT_MAX_PLAIN_LENGTH; */
-	return 65536;
+        return 65536;
 
     case TLS_ST_CR_CERT_STATUS:
         return SSL3_RT_MAX_PLAIN_LENGTH;

--- a/ssl/statem/statem_srvr.c
+++ b/ssl/statem/statem_srvr.c
@@ -1134,7 +1134,7 @@ size_t ossl_statem_server_max_message_size(SSL *s)
        * longer PQC signatures. (See https://github.com/openssl/openssl/issues/6433)
        */
       /* return SSL3_RT_MAX_PLAIN_LENGTH; */
-	return 65536;
+        return 65536;
 
 #ifndef OPENSSL_NO_NEXTPROTONEG
     case TLS_ST_SR_NEXT_PROTO:

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -1865,8 +1865,8 @@ void ssl_set_sig_mask(uint32_t *pmask_a, SSL *s, int op)
             continue;
 
         clu = ssl_cert_lookup_by_idx(lu->sig_idx);
-	if (clu == NULL)
-		continue;
+        if (clu == NULL)
+                continue;
 
         /* If algorithm is disabled see if we can enable it */
         if ((clu->amask & disabled_mask) != 0


### PR DESCRIPTION
Some files had some tab-intented lines instead of having indentation by spaces. This made reading the code a bit harder.

I haven't done the `git blame` to figure out who should ~reconsider their life choices~ reconfigure their editor but perhaps the guilty will see this PR :stuck_out_tongue:.