### PR TITLE
Fixed rsa3072-picnicL1FS CA cert issuance

### DIFF
--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -782,6 +782,7 @@ static int oqs_item_verify(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
     if (
 	(nid != NID_picnicL1FS &&
 	 nid != NID_p256_picnicL1FS &&
+	 nid != NID_rsa3072_picnicL1FS &&
 	 nid != NID_qteslaI &&
 	 nid != NID_p256_qteslaI &&
 	 nid != NID_qteslaIIIsize &&


### PR DESCRIPTION
Added missing check for rsa3072-picnicL1FS combo in oqs method used to verify cert requests.
