### PR TITLE
Only keep round2 candidates in OpenSSLv1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ The following additional mechanisms are supported only when using liboqs's nist-
 
 - `kyber512`, `kyber768`, `kyber1024`
 - `ledakem_C1_N02`, `ledakem_C1_N03`, `ledakem_C1_N04`, `ledakem_C3_N02`, `ledakem_C3_N03`, `ledakem_C3_N04`, `ledakem_C5_N02`
-- `lima_2p_1024_cca`, `lima_2p_2048_cca`, `lima_sp_1018_cca` (not for hybrid), `lima_sp_1306_cca`, `lima_sp_1822_cca`
 - `saber_light_saber` (not for hybrid), `saber_saber`, `saber_fire_saber`
 
 Note that some mechanisms from the nist-branch have been disabled in OpenSSL because they use keys/ciphertexts too large for TLS 1.3.

--- a/apps/s_cb.c
+++ b/apps/s_cb.c
@@ -444,11 +444,6 @@ static const char* OQS_CURVE_ID_NAME_STR(int id) {
   case 0x0212: return "newhope1024cca";
 #if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-    /*
-  case 0x0213: return "bigquake1";
-  case 0x0214: return "bigquake3";
-  case 0x0215: return "bigquake5";
-    */
   case 0x0216: return "kyber512";
   case 0x0217: return "kyber768";
   case 0x0218: return "kyber1024";
@@ -463,23 +458,9 @@ static const char* OQS_CURVE_ID_NAME_STR(int id) {
   case 0x0220: return "ledakem_C5_N03";
   case 0x0221: return "ledakem_C5_N04";
     */
-  case 0x0222: return "lima_2p_1024_cca";
-  case 0x0223: return "lima_2p_2048_cca";
-  case 0x0224: return "lima_sp_1018_cca";
-  case 0x0225: return "lima_sp_1306_cca";
-  case 0x0226: return "lima_sp_1822_cca";
-    /*
-  case 0x0227: return "lima_sp_2062_cca";
-    */
   case 0x0228: return "saber_light_saber";
   case 0x0229: return "saber_saber";
   case 0x022a: return "saber_fire_saber";
-    /*
-  case 0x022b: return "titanium_cca_std";
-  case 0x022c: return "titanium_cca_hi";
-  case 0x022d: return "titanium_cca_med";
-  case 0x022e: return "titanium_cca_super";
-    */
 #endif
   /* ADD_MORE_OQS_KEM_HERE */
   case 0x02FF: return "p256-oqs_kem_default hybrid";
@@ -492,18 +473,12 @@ static const char* OQS_CURVE_ID_NAME_STR(int id) {
   case 0x0306: return "p256-bike3l1 hybrid";
   case 0x0307: return "p256-newhope512cca hybrid";
 #if defined(OQS_NIST_BRANCH)
-    /*
-  case 0x0308: return "p256-bigquake1 hybrid";
-    */
   case 0x0309: return "p256-kyber512 hybrid";
   case 0x030a: return "p256-ledakem_C1_N02 hybrid";
   case 0x030b: return "p256-ledakem_C1_N03 hybrid";
   case 0x030c: return "p256-ledakem_C1_N04 hybrid";
     /*
-  case 0x030d: return "p256-lima_sp_1018_cca hybrid";
   case 0x030e: return "p256-saber_light_saber hybrid";
-  case 0x030f: return "p256-titanium_cca_std hybrid";
-  case 0x0310: return "p256-titanium_cca_med hybrid";
     */
 #endif
   /* ADD_MORE_OQS_KEM_HERE (L1 schemes) */

--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -479,14 +479,10 @@
 #define NID_OQS_NEWHOPE_1024_CCA (NID_OQS_START + 19)
 #if defined(OQS_NIST_BRANCH)
 /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-/*
-#define NID_OQS_bigquake1        (NID_OQS_START + 20)
-#define NID_OQS_bigquake3        (NID_OQS_START + 21)
-#define NID_OQS_bigquake5        (NID_OQS_START + 22)
-*/
 #define NID_OQS_kyber512         (NID_OQS_START + 23)
 #define NID_OQS_kyber768         (NID_OQS_START + 24)
 #define NID_OQS_kyber1024        (NID_OQS_START + 25)
+/* OQS note: ledakem was replaced with LEDAcrypt in round 2; needs an update */
 #define NID_OQS_ledakem_C1_N02   (NID_OQS_START + 26)
 #define NID_OQS_ledakem_C1_N03   (NID_OQS_START + 27)
 #define NID_OQS_ledakem_C1_N04   (NID_OQS_START + 28)
@@ -498,23 +494,9 @@
 #define NID_OQS_ledakem_C5_N03   (NID_OQS_START + 33)
 #define NID_OQS_ledakem_C5_N04   (NID_OQS_START + 34)
 */
-#define NID_OQS_lima_2p_1024_cca (NID_OQS_START + 35)
-#define NID_OQS_lima_2p_2048_cca (NID_OQS_START + 36)
-#define NID_OQS_lima_sp_1018_cca (NID_OQS_START + 37)
-#define NID_OQS_lima_sp_1306_cca (NID_OQS_START + 38)
-#define NID_OQS_lima_sp_1822_cca (NID_OQS_START + 39)
-/*
-#define NID_OQS_lima_sp_2062_cca (NID_OQS_START + 40)
-*/
 #define NID_OQS_saber_light_saber (NID_OQS_START + 41)
 #define NID_OQS_saber_saber      (NID_OQS_START + 42)
 #define NID_OQS_saber_fire_saber (NID_OQS_START + 43)
-/*
-#define NID_OQS_titanium_cca_std (NID_OQS_START + 44)
-#define NID_OQS_titanium_cca_hi  (NID_OQS_START + 45)
-#define NID_OQS_titanium_cca_med (NID_OQS_START + 46)
-#define NID_OQS_titanium_cca_super (NID_OQS_START + 47)
-*/
 #endif
 /* ADD_MORE_OQS_KEM_HERE (update counter below)*/
 #define NID_OQS_END              (NID_OQS_START + 47)
@@ -532,18 +514,13 @@
 #define NID_OQS_p256_BIKE3_L1         (NID_HYBRID_START + 7)
 #define NID_OQS_p256_NEWHOPE_512_CCA  (NID_HYBRID_START + 8)
 #if defined(OQS_NIST_BRANCH)
-/*
-#define NID_OQS_p256_bigquake1        (NID_HYBRID_START + 9)
-*/
 #define NID_OQS_p256_kyber512         (NID_HYBRID_START + 10)
+/* OQS note: ledakem was replaced with LEDAcrypt in round 2; needs an update */
 #define NID_OQS_p256_ledakem_C1_N02   (NID_HYBRID_START + 11)
 #define NID_OQS_p256_ledakem_C1_N03   (NID_HYBRID_START + 12)
 #define NID_OQS_p256_ledakem_C1_N04   (NID_HYBRID_START + 13)
 /*
-#define NID_OQS_p256_lima_sp_1018_cca (NID_HYBRID_START + 14)
 #define NID_OQS_p256_saber_light_saber (NID_HYBRID_START + 15)
-#define NID_OQS_p256_titanium_cca_std (NID_HYBRID_START + 16)
-#define NID_OQS_p256_titanium_cca_med (NID_HYBRID_START + 17)
 */
 #endif
 /* ADD_MORE_OQS_KEM_HERE (L1 schemes, update counter below) */
@@ -559,9 +536,6 @@
 #define OQS_KEM_CURVEID_NIST_BRANCH(nid) \
   /* schemes only in nist branch */ \
   /* some schemes are disabled because their keys/ciphertext are too big for TLS */ \
-  /* (nid == NID_OQS_bigquake1 ? 0x0213 : */ \
-  /* (nid == NID_OQS_bigquake3 ? 0x0214 : */ \
-  /* (nid == NID_OQS_bigquake5 ? 0x0215 : */ \
   (nid == NID_OQS_kyber512 ? 0x0216 : \
   (nid == NID_OQS_kyber768 ? 0x0217 : \
   (nid == NID_OQS_kyber1024 ? 0x0218 : \
@@ -577,17 +551,7 @@
   (nid == NID_OQS_saber_light_saber ? 0x0228 : \
   (nid == NID_OQS_saber_saber ? 0x0229 : \
   (nid == NID_OQS_saber_fire_saber ? 0x022a : \
-  (nid == NID_OQS_lima_2p_1024_cca ? 0x0222 : \
-  (nid == NID_OQS_lima_2p_2048_cca ? 0x0223 : \
-  (nid == NID_OQS_lima_sp_1018_cca ? 0x0224 : \
-  (nid == NID_OQS_lima_sp_1306_cca ? 0x0225 : \
-  (nid == NID_OQS_lima_sp_1822_cca ? 0x0226 : \
-  /* (nid == NID_OQS_lima_sp_2062_cca ? 0x0227 : */ \
-  /* (nid == NID_OQS_titanium_cca_std ? 0x022b : */ \
-  /* (nid == NID_OQS_titanium_cca_hi ? 0x022c : */ \
-  /* (nid == NID_OQS_titanium_cca_med ? 0x022d : */ \
-  /* (nid == NID_OQS_titanium_cca_super ? 0x022e : */ \
-   0))))))))))))))))))
+   0)))))))))))))
 #else
 #define OQS_KEM_CURVEID_NIST_BRANCH(nid) \
   /* schemes only in master branch */ \
@@ -623,15 +587,11 @@
 #define OQS_KEM_HYBRID_CURVEID_NIST_BRANCH(nid) \
   /* schemes only in nist branch */ \
   /* some schemes are disabled because their keys/ciphertext are too big for TLS */ \
-  /* (nid == NID_OQS_p256_bigquake1       ? 0x0308 : */ \
   (nid == NID_OQS_p256_kyber512         ? 0x0309 : \
   (nid == NID_OQS_p256_ledakem_C1_N02   ? 0x030a : \
   (nid == NID_OQS_p256_ledakem_C1_N03   ? 0x030b : \
   (nid == NID_OQS_p256_ledakem_C1_N04   ? 0x030c : \
-  /* (nid == NID_OQS_p256_lima_sp_1018_cca ? 0x030d : */ \
   /* (nid == NID_OQS_p256_saber_light_saber ? 0x030e :  */ \
-  /* (nid == NID_OQS_p256_titanium_cca_std ? 0x030f : */ \
-  /* (nid == NID_OQS_p256_titanium_cca_med ? 0x0310 : */ \
    0))))
 #else
 #define OQS_KEM_HYBRID_CURVEID_NIST_BRANCH(nid) \
@@ -657,9 +617,6 @@
 #define OQS_KEM_NID_NIST_BRANCH(curveID) \
   /* schemes only in nist branch */ \
   /* some schemes are disabled because their keys/ciphertext are too big for TLS */ \
-  /* (curveID == 0x0213 || curveID == 0x0308 ? NID_OQS_bigquake1 : */ \
-  /* (curveID == 0x0214 ? NID_OQS_bigquake3 : */ \
-  /* (curveID == 0x0215 ? NID_OQS_bigquake5 : */ \
   (curveID == 0x0216 || curveID == 0x0309 ? NID_OQS_kyber512 : \
   (curveID == 0x0217 ? NID_OQS_kyber768 : \
   (curveID == 0x0218 ? NID_OQS_kyber1024 : \
@@ -672,20 +629,10 @@
   (curveID == 0x021f ? NID_OQS_ledakem_C5_N02 : \
   /* (curveID == 0x0220 ? NID_OQS_ledakem_C5_N03 : */ \
   /* (curveID == 0x0221 ? NID_OQS_ledakem_C5_N04 : */ \
-  (curveID == 0x0222 ? NID_OQS_lima_2p_1024_cca : \
-  (curveID == 0x0223 ? NID_OQS_lima_2p_2048_cca : \
-  (curveID == 0x0224 /* || curveID == 0x030d */ ? NID_OQS_lima_sp_1018_cca : \
-  (curveID == 0x0225 ? NID_OQS_lima_sp_1306_cca : \
-  (curveID == 0x0226 ? NID_OQS_lima_sp_1822_cca : \
-  /* (curveID == 0x0227 ? NID_OQS_lima_sp_2062_cca : */         \
   (curveID == 0x0228 /* || (curveID == 0x030e: */ ? NID_OQS_saber_light_saber : \
   (curveID == 0x0229 ? NID_OQS_saber_saber : \
   (curveID == 0x022a ? NID_OQS_saber_fire_saber : \
-   /* (curveID == 0x022b || curveID == 0x030f ? NID_OQS_titanium_cca_std : */ \
-   /* (curveID == 0x022c ? NID_OQS_titanium_cca_hi : */ \
-   /* (curveID == 0x022d || curveID == 0x0310 ? NID_OQS_titanium_cca_med : */ \
-   /* (curveID == 0x022e ? NID_OQS_titanium_cca_super : */ \
-   0 ))))))))))))))))))
+   0 )))))))))))))
 #else
 #define OQS_KEM_NID_NIST_BRANCH(curveID) \
   /* schemes only in master branch */ \
@@ -727,9 +674,6 @@
 #define OQS_ALG_NAME_NIST_BRANCH(nid) \
   /* schemes only in nist branch */ \
   /* some schemes are disabled because their keys/ciphertext are too big for TLS */ \
-  /* (nid == NID_OQS_bigquake1          ? OQS_KEM_alg_BIG_QUAKE_1 */ \
-  /* (nid == NID_OQS_bigquake3          ? OQS_KEM_alg_BIG_QUAKE_3 */ \
-  /* (nid == NID_OQS_bigquake5          ? OQS_KEM_alg_BIG_QUAKE_5 */ \
   (nid == NID_OQS_kyber512           ? OQS_KEM_alg_kyber512 : \
   (nid == NID_OQS_kyber768           ? OQS_KEM_alg_kyber768 : \
   (nid == NID_OQS_kyber1024          ? OQS_KEM_alg_kyber1024 : \
@@ -742,20 +686,10 @@
   (nid == NID_OQS_ledakem_C5_N02     ? OQS_KEM_alg_ledakem_C5_N02 : \
   /* (nid == NID_OQS_ledakem_C5_N03     ? OQS_KEM_alg_ledakem_C5_N03 : */ \
   /* (nid == NID_OQS_ledakem_C5_N04     ? OQS_KEM_alg_ledakem_C5_N04 : */ \
-  (nid == NID_OQS_lima_2p_1024_cca   ? OQS_KEM_alg_lima_2p_1024_cca_kem : \
-  (nid == NID_OQS_lima_2p_2048_cca   ? OQS_KEM_alg_lima_2p_2048_cca_kem : \
-  (nid == NID_OQS_lima_sp_1018_cca   ? OQS_KEM_alg_lima_sp_1018_cca_kem : \
-  (nid == NID_OQS_lima_sp_1306_cca   ? OQS_KEM_alg_lima_sp_1306_cca_kem : \
-  (nid == NID_OQS_lima_sp_1822_cca   ? OQS_KEM_alg_lima_sp_1822_cca_kem : \
-  /* (nid == NID_OQS_lima_sp_2062_cca   ? OQS_KEM_alg_lima_sp_2062_cca_kem : */ \
   (nid == NID_OQS_saber_light_saber  ? OQS_KEM_alg_saber_light_saber_kem : \
   (nid == NID_OQS_saber_saber        ? OQS_KEM_alg_saber_saber_kem : \
   (nid == NID_OQS_saber_fire_saber   ? OQS_KEM_alg_saber_fire_saber_kem : \
-  /* (nid == NID_OQS_titanium_cca_std   ? OQS_KEM_alg_titanium_cca_std_kem : */ \
-  /* (nid == NID_OQS_titanium_cca_hi    ? OQS_KEM_alg_titanium_cca_hi_kem : */ \
-  /* (nid == NID_OQS_titanium_cca_med   ? OQS_KEM_alg_titanium_cca_med_kem : */ \
-  /* (nid == NID_OQS_titanium_cca_super ? OQS_KEM_alg_titanium_cca_super_kem : */ \
-   0 ))))))))))))))))))
+   0 )))))))))))))
 #else
 #define OQS_ALG_NAME_NIST_BRANCH(nid) \
   /* schemes only in master branch */ \

--- a/ssl/ssl_oqs_extra.h
+++ b/ssl/ssl_oqs_extra.h
@@ -48,14 +48,6 @@ static int OQS_nid_from_string(const char *value) {
     nid = NID_OQS_NEWHOPE_1024_CCA;
 #if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-    /*
-  } else if (strncmp(value,"bigquake1", len) == 0) {
-    nid = NID_OQS_bigquake1;
-  } else if (strncmp(value,"bigquake3", len) == 0) {
-    nid = NID_OQS_bigquake3;
-  } else if (strncmp(value,"bigquake5", len) == 0) {
-    nid = NID_OQS_bigquake5;
-    */
   } else if (strncmp(value,"kyber512", len) == 0) {
     nid = NID_OQS_kyber512;
   } else if (strncmp(value,"kyber768", len) == 0) {
@@ -82,36 +74,12 @@ static int OQS_nid_from_string(const char *value) {
   } else if (strncmp(value,"ledakem_C5_N04", len) == 0) {
     nid = NID_OQS_ledakem_C5_N04;
     */
-  } else if (strncmp(value,"lima_2p_1024_cca", len) == 0) {
-    nid = NID_OQS_lima_2p_1024_cca;
-  } else if (strncmp(value,"lima_2p_2048_cca", len) == 0) {
-    nid = NID_OQS_lima_2p_2048_cca;
-  } else if (strncmp(value,"lima_sp_1018_cca", len) == 0) {
-    nid = NID_OQS_lima_sp_1018_cca;
-  } else if (strncmp(value,"lima_sp_1306_cca", len) == 0) {
-    nid = NID_OQS_lima_sp_1306_cca;
-  } else if (strncmp(value,"lima_sp_1822_cca", len) == 0) {
-    nid = NID_OQS_lima_sp_1822_cca;
-    /*
-  } else if (strncmp(value,"lima_sp_2062_cca", len) == 0) {
-    nid = NID_OQS_lima_sp_2062_cca;
-    */
   } else if (strncmp(value,"saber_light_saber", len) == 0) {
     nid = NID_OQS_saber_light_saber;
   } else if (strncmp(value,"saber_saber", len) == 0) {
     nid = NID_OQS_saber_saber;
   } else if (strncmp(value,"saber_fire_saber", len) == 0) {
     nid = NID_OQS_saber_fire_saber;
-    /*
-  } else if (strncmp(value,"titanium_cca_std", len) == 0) {
-    nid = NID_OQS_titanium_cca_std;
-  } else if (strncmp(value,"titanium_cca_hi", len) == 0) {
-    nid = NID_OQS_titanium_cca_hi;
-  } else if (strncmp(value,"titanium_cca_med", len) == 0) {
-    nid = NID_OQS_titanium_cca_med;
-  } else if (strncmp(value,"titanium_cca_super", len) == 0) {
-    nid = NID_OQS_titanium_cca_super;
-    */
 #endif
   /* ADD_MORE_OQS_KEM_HERE */
   /* hybrid algs */
@@ -136,10 +104,6 @@ static int OQS_nid_from_string(const char *value) {
   } else if (strncmp(value,"p256-newhope512cca", len) == 0) {
     nid = NID_OQS_p256_NEWHOPE_512_CCA;
 #if defined(OQS_NIST_BRANCH)
-    /*
-  } else if (strncmp(value,"p256-bigquake1", len) == 0) {
-    nid = NID_OQS_p256_bigquake1;
-    */
   } else if (strncmp(value,"p256-kyber512", len) == 0) {
     nid = NID_OQS_p256_kyber512;
   } else if (strncmp(value,"p256-ledakem_C1_N02", len) == 0) {
@@ -149,14 +113,8 @@ static int OQS_nid_from_string(const char *value) {
   } else if (strncmp(value,"p256-ledakem_C1_N04", len) == 0) {
     nid = NID_OQS_p256_ledakem_C1_N04;
     /*
-  } else if (strncmp(value,"p256-lima_sp_1018_cca", len) == 0) {
-    nid = NID_OQS_p256_lima_sp_1018_cca;
   } else if (strncmp(value,"p256-saber_light_saber", len) == 0) {
     nid = NID_OQS_p256_saber_light_saber;
-  } else if (strncmp(value,"p256-titanium_cca_std", len) == 0) {
-    nid = NID_OQS_p256_titanium_cca_std;
-  } else if (strncmp(value,"p256-titanium_cca_med", len) == 0) {
-    nid = NID_OQS_p256_titanium_cca_med;
     */
 #endif
   }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -198,9 +198,6 @@ static const TLS_GROUP_INFO oqs_nid_list[] = {
     {NID_OQS_NEWHOPE_1024_CCA, 256, TLS_CURVE_CUSTOM}, /* newhope1024cca (0x0212) */
 #if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-    /* {NID_OQS_bigquake1, 128, TLS_CURVE_CUSTOM}, */ /* bigquake1 (0x0213) */
-    /* {NID_OQS_bigquake3, 192, TLS_CURVE_CUSTOM}, */ /* bigquake3 (0x0214) */
-    /* {NID_OQS_bigquake5, 256, TLS_CURVE_CUSTOM}, */ /* bigquake5 (0x0215) */
     {NID_OQS_kyber512, 128, TLS_CURVE_CUSTOM}, /* kyber512 (0x0216) */
     {NID_OQS_kyber768, 192, TLS_CURVE_CUSTOM}, /* kyber768 (0x0217) */
     {NID_OQS_kyber1024, 256, TLS_CURVE_CUSTOM}, /* kyber1024 (0x0218) */
@@ -213,19 +210,9 @@ static const TLS_GROUP_INFO oqs_nid_list[] = {
     {NID_OQS_ledakem_C5_N02, 256, TLS_CURVE_CUSTOM}, /* ledakem_C5_N02 (0x021f) */
     /* {NID_OQS_ledakem_C5_N03, 256, TLS_CURVE_CUSTOM}, */ /* ledakem_C5_N03 (0x0220) */
     /* {NID_OQS_ledakem_C5_N04, 256, TLS_CURVE_CUSTOM}, */ /* ledakem_C5_N04 (0x0221) */
-    {NID_OQS_lima_2p_1024_cca, 192, TLS_CURVE_CUSTOM}, /* lima_2p_1024_cca (0x0222) */
-    {NID_OQS_lima_2p_2048_cca, 192, TLS_CURVE_CUSTOM}, /* lima_2p_2048_cca (0x0223) */ /* FIXMEOQS: what is the security level for NIST level 4? */
-    {NID_OQS_lima_sp_1018_cca, 128, TLS_CURVE_CUSTOM}, /* lima_sp_1018_cca (0x0224) */
-    {NID_OQS_lima_sp_1306_cca, 128, TLS_CURVE_CUSTOM}, /* lima_sp_1306_cca (0x0225) */ /* FIXMEOQS: what is the security level for NIST level 2? */
-    {NID_OQS_lima_sp_1822_cca, 192, TLS_CURVE_CUSTOM}, /* lima_sp_1822_cca (0x0226) */
-    /* {NID_OQS_lima_sp_2062_cca, 192, TLS_CURVE_CUSTOM}, */ /* lima_sp_2062_cca (0x0227) */ /* FIXMEOQS: what is the security level for NIST level 4? */
     {NID_OQS_saber_light_saber, 128, TLS_CURVE_CUSTOM}, /* saber_light_saber (0x0228) */
     {NID_OQS_saber_saber, 192, TLS_CURVE_CUSTOM}, /* saber_saber (0x0229) */
     {NID_OQS_saber_fire_saber, 256, TLS_CURVE_CUSTOM}, /* saber_fire_saber (0x022a) */
-    /* {NID_OQS_titanium_cca_std, 128, TLS_CURVE_CUSTOM}, /*titanium_cca_hi titanium_cca_std (0x022b) */
-    /* {NID_OQS_titanium_cca_hi, 192, TLS_CURVE_CUSTOM}, */ /* titanium_cca_hi (0x022c) */
-    /* {NID_OQS_titanium_cca_med, 128, TLS_CURVE_CUSTOM}, */ /* titanium_cca_med (0x022d) */
-    /* {NID_OQS_titanium_cca_super, 256, TLS_CURVE_CUSTOM}, */ /* titanium_cca_super (0x022e) */
 #endif
     /* ADD_MORE_OQS_KEM_HERE */
 };
@@ -244,15 +231,11 @@ static const TLS_GROUP_INFO oqs_hybrid_nid_list[] = {
     {NID_OQS_p256_NEWHOPE_512_CCA, 128, TLS_CURVE_CUSTOM}, /* p256 + newhope512cca hybrid (0x0307) */
 #if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-    /* {NID_OQS_p256_bigquake1, 128, TLS_CURVE_CUSTOM}, */ /* p256 + bigquake1 hybrid (0x0308) */
     {NID_OQS_p256_kyber512, 128, TLS_CURVE_CUSTOM}, /* p256 + kyber512 hybrid (0x0309) */
     {NID_OQS_p256_ledakem_C1_N02, 128, TLS_CURVE_CUSTOM}, /* p256 + ledakem_C1_N02 hybrid (0x030a) */
     {NID_OQS_p256_ledakem_C1_N03, 128, TLS_CURVE_CUSTOM}, /* p256 + ledakem_C1_N03 hybrid (0x030b) */
     {NID_OQS_p256_ledakem_C1_N04, 128, TLS_CURVE_CUSTOM}, /* p256 + ledakem_C1_N04 hybrid (0x030c) */
-    /* {NID_OQS_p256_lima_sp_1018_cca, 128, TLS_CURVE_CUSTOM}, */ /* p256 + lima_sp_1018_cca hybrid (0x030d) */
     /* {NID_OQS_p256_saber_light_saber, 128, TLS_CURVE_CUSTOM}, */ /* p256 + saber_light_saber hybrid (0x030e) */
-    /* {NID_OQS_p256_titanium_cca_std, 128, TLS_CURVE_CUSTOM}, */ /* p256 + titanium_cca_std hybrid (0x030f) */
-    /* {NID_OQS_p256_titanium_cca_med, 128, TLS_CURVE_CUSTOM}, */ /* p256 + titanium_cca_med hybrid (0x0310) */
 #endif
     /* ADD_MORE_OQS_KEM_HERE (L1 schemes) */
 };
@@ -296,9 +279,6 @@ static const uint16_t eccurves_default[] = {
     0x0212, /* OQS newhope1024cca */
 #if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-    /* 0x0213, */ /* OQS bigquake1 */
-    /* 0x0214, */ /* OQS bigquake3 */
-    /* 0x0215, */ /* OQS bigquake5 */
     0x0216, /* OQS kyber512 */
     0x0217, /* OQS kyber768 */
     0x0218, /* OQS kyber1024 */
@@ -311,19 +291,9 @@ static const uint16_t eccurves_default[] = {
     0x021f, /* OQS ledakem_C5_N02 */
     /* 0x0220, */ /* OQS ledakem_C5_N03 */
     /* 0x0221, */ /* OQS ledakem_C5_N04 */
-    0x0222, /* OQS lima_2p_1024_cca */
-    0x0223, /* OQS lima_2p_2048_cca */
-    0x0224, /* OQS lima_sp_1018_cca */
-    0x0225, /* OQS lima_sp_1306_cca */
-    0x0226, /* OQS lima_sp_1822_cca */
-    0x0227, /* OQS lima_sp_2062_cca */
     0x0228, /* OQS saber_light_saber */
     0x0229, /* OQS saber_saber */
     0x022a, /* OQS saber_fire_saber */
-    /* 0x022b, */ /* OQS titanium_cca_std */
-    /* 0x022c, */ /* OQS titanium_cca_hi */
-    /* 0x022d, */ /* OQS titanium_cca_med */
-    /* 0x022e, */ /* OQS titanium_cca_super */
 #endif
     /* ADD_MORE_OQS_KEM_HERE */
     0x02FF, /* p256 - OQS default KEM hybrid */
@@ -338,15 +308,11 @@ static const uint16_t eccurves_default[] = {
     0x0306, /* p256 - OQS bike3l1 hybrid */
     0x0307, /* p256 - OQS newhope512cca hybrid */
 #if defined(OQS_NIST_BRANCH)
-    /* 0x0308, */ /* p256 - OQS bigquake1 hybrid */
     0x0309, /* p256 - OQS kyber512 hybrid */
     0x030a, /* p256 - OQS ledakem_C1_N02 hybrid */
     0x030b, /* p256 - OQS ledakem_C1_N03 hybrid */
     0x030c, /* p256 - OQS ledakem_C1_N04 hybrid */
-    /* 0x030d, */ /* p256 - OQS lima_sp_1018_cca hybrid */
     /* 0x030e, */ /* p256 - OQS saber_light_saber hybrid */
-    /* 0x030f, */ /* p256 - OQS titanium_cca_std hybrid */
-    /* 0x0310, */ /* p256 - OQS titanium_cca_med hybrid */
 #endif
     /* ADD_MORE_OQS_KEM_HERE (L1 schemes) */
 };

--- a/ssl/t1_trce.c
+++ b/ssl/t1_trce.c
@@ -554,11 +554,6 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
     {OQS_KEM_CURVEID(NID_OQS_NEWHOPE_1024_CCA), "newhope1024cca"},
 #if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-    /*
-    {OQS_KEM_CURVEID(NID_OQS_bigquake1), "bigquake1"},
-    {OQS_KEM_CURVEID(NID_OQS_bigquake3), "bigquake3"},
-    {OQS_KEM_CURVEID(NID_OQS_bigquake5), "bigquake5"},
-    */
     {OQS_KEM_CURVEID(NID_OQS_kyber512), "kyber512"},
     {OQS_KEM_CURVEID(NID_OQS_kyber768), "kyber768"},
     {OQS_KEM_CURVEID(NID_OQS_kyber1024), "kyber1024"},
@@ -573,23 +568,9 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
     {OQS_KEM_CURVEID(NID_OQS_ledakem_C5_N03), "ledakem_C5_N03"},
     {OQS_KEM_CURVEID(NID_OQS_ledakem_C5_N04), "ledakem_C5_N04"},
     */
-    {OQS_KEM_CURVEID(NID_OQS_lima_2p_1024_cca), "lima_2p_1024_cca"},
-    {OQS_KEM_CURVEID(NID_OQS_lima_2p_2048_cca), "lima_2p_2048_cca"},
-    {OQS_KEM_CURVEID(NID_OQS_lima_sp_1018_cca), "lima_sp_1018_cca"},
-    {OQS_KEM_CURVEID(NID_OQS_lima_sp_1306_cca), "lima_sp_1306_cca"},
-    {OQS_KEM_CURVEID(NID_OQS_lima_sp_1822_cca), "lima_sp_1822_cca"},
-    /*
-    {OQS_KEM_CURVEID(NID_OQS_lima_sp_2062_cca), "lima_sp_2062_cca"},
-    */
     {OQS_KEM_CURVEID(NID_OQS_saber_light_saber), "saber_light_saber"},
     {OQS_KEM_CURVEID(NID_OQS_saber_saber), "saber_saber"},
     {OQS_KEM_CURVEID(NID_OQS_saber_fire_saber), "saber_fire_saber"},
-    /*
-    {OQS_KEM_CURVEID(NID_OQS_titanium_cca_std), "titanium_cca_std"},
-    {OQS_KEM_CURVEID(NID_OQS_titanium_cca_hi), "titanium_cca_hi"},
-    {OQS_KEM_CURVEID(NID_OQS_titanium_cca_med), "titanium_cca_med"},
-    {OQS_KEM_CURVEID(NID_OQS_titanium_cca_super), "titanium_cca_super"},
-    */
 #endif
     /* ADD_MORE_OQS_KEM_HERE */
     {OQS_KEM_CURVEID(NID_OQS_p256_KEM_DEFAULT), "p256 - OQS KEM default hybrid"},
@@ -603,18 +584,12 @@ static const ssl_trace_tbl ssl_groups_tbl[] = {
     {OQS_KEM_CURVEID(NID_OQS_p256_BIKE2_L1), "p256 - bike2l1 hybrid"},
     {OQS_KEM_CURVEID(NID_OQS_p256_BIKE3_L1), "p256 - bike3l1 hybrid"},
 #if defined(OQS_NIST_BRANCH)
-    /*
-    {OQS_KEM_CURVEID(NID_OQS_p256_bigquake1), "p256 - bigquake1"},
-    */
     {OQS_KEM_CURVEID(NID_OQS_p256_kyber512), "p256 - kyber512"},
     {OQS_KEM_CURVEID(NID_OQS_p256_ledakem_C1_N02), "p256 - ledakem_C1_N02"},
     {OQS_KEM_CURVEID(NID_OQS_p256_ledakem_C1_N03), "p256 - ledakem_C1_N03"},
     {OQS_KEM_CURVEID(NID_OQS_p256_ledakem_C1_N04), "p256 - ledakem_C1_N04"},
     /*
-    {OQS_KEM_CURVEID(NID_OQS_p256_lima_sp_1018_cca), "p256 - lima_sp_1018_cca"},
     {OQS_KEM_CURVEID(NID_OQS_p256_saber_light_saber), "p256 - saber_light_saber"},
-    {OQS_KEM_CURVEID(NID_OQS_p256_titanium_cca_std), "p256 - titanium_cca_std"},
-    {OQS_KEM_CURVEID(NID_OQS_p256_titanium_cca_med), "p256 - titanium_cca_med"},
     */
 #endif
     /* ADD_MORE_OQS_KEM_HERE (L1 schemes) */


### PR DESCRIPTION
Removed round1 candidates that didn't make it to round2 (bigquake, lima, titanium) in OpenSSL v1.1.1 (TLS 1.3)
