### PR TITLE
Fixes oqs nid table indexing

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -454,81 +454,76 @@
 /* NID for OQS KEM algs. Pick values starting way above NUM_NID (defined in obj_dat.h)
    to avoid conflicts with dynamically registered schemes (we keep things local to
    avoid modifying the libcrypto layer) */
-#define NID_OQS_START            2000
-#define NID_OQS_KEM_DEFAULT      (NID_OQS_START + 0)
-#define NID_OQS_SIKE_503         (NID_OQS_START + 1)
-#define NID_OQS_SIKE_751         (NID_OQS_START + 2)
-#if !defined(OQS_NIST_BRANCH)
-#define NID_OQS_SIDH_503         (NID_OQS_START + 3)
-#define NID_OQS_SIDH_751         (NID_OQS_START + 4)
-#endif
-#define NID_OQS_Frodo_640_AES    (NID_OQS_START + 5)
-#define NID_OQS_Frodo_640_cshake (NID_OQS_START + 6)
-#define NID_OQS_Frodo_976_AES    (NID_OQS_START + 7)
-#define NID_OQS_Frodo_976_cshake (NID_OQS_START + 8)
-#define NID_OQS_BIKE1_L1         (NID_OQS_START + 9)
-#define NID_OQS_BIKE1_L3         (NID_OQS_START + 10)
-#define NID_OQS_BIKE1_L5         (NID_OQS_START + 11)
-#define NID_OQS_BIKE2_L1         (NID_OQS_START + 12)
-#define NID_OQS_BIKE2_L3         (NID_OQS_START + 13)
-#define NID_OQS_BIKE2_L5         (NID_OQS_START + 14)
-#define NID_OQS_BIKE3_L1         (NID_OQS_START + 15)
-#define NID_OQS_BIKE3_L3         (NID_OQS_START + 16)
-#define NID_OQS_BIKE3_L5         (NID_OQS_START + 17)
-#define NID_OQS_NEWHOPE_512_CCA  (NID_OQS_START + 18)
-#define NID_OQS_NEWHOPE_1024_CCA (NID_OQS_START + 19)
-#if defined(OQS_NIST_BRANCH)
+#define NID_OQS_START            0x01FF
+#define NID_OQS_KEM_DEFAULT      0x01FF
+#define NID_OQS_SIKE_503         0x0200
+#define NID_OQS_SIKE_751         0x0201
+#define NID_OQS_SIDH_503         0x0202
+#define NID_OQS_SIDH_751         0x0203
+#define NID_OQS_Frodo_640_AES    0x0204
+#define NID_OQS_Frodo_640_cshake 0x0205
+#define NID_OQS_Frodo_976_AES    0x0206
+#define NID_OQS_Frodo_976_cshake 0x0207
+#define NID_OQS_BIKE1_L1         0x0208
+#define NID_OQS_BIKE1_L3         0x0209
+#define NID_OQS_BIKE1_L5         0x020a
+#define NID_OQS_BIKE2_L1         0x020b
+#define NID_OQS_BIKE2_L3         0x020c
+#define NID_OQS_BIKE2_L5         0x020d
+#define NID_OQS_BIKE3_L1         0x020e
+#define NID_OQS_BIKE3_L3         0x020f
+#define NID_OQS_BIKE3_L5         0x0210
+#define NID_OQS_NEWHOPE_512_CCA  0x0211
+#define NID_OQS_NEWHOPE_1024_CCA 0x0212
 /* some schemes are disabled because their keys/ciphertext are too big for TLS */
-#define NID_OQS_kyber512         (NID_OQS_START + 23)
-#define NID_OQS_kyber768         (NID_OQS_START + 24)
-#define NID_OQS_kyber1024        (NID_OQS_START + 25)
+/* skip 0x0213, 0x0214, 0x0215; removed round1 schemes */
+#define NID_OQS_kyber512         0x0216
+#define NID_OQS_kyber768         0x0217
+#define NID_OQS_kyber1024        0x0218
 /* OQS note: ledakem was replaced with LEDAcrypt in round 2; needs an update */
-#define NID_OQS_ledakem_C1_N02   (NID_OQS_START + 26)
-#define NID_OQS_ledakem_C1_N03   (NID_OQS_START + 27)
-#define NID_OQS_ledakem_C1_N04   (NID_OQS_START + 28)
-#define NID_OQS_ledakem_C3_N02   (NID_OQS_START + 29)
-#define NID_OQS_ledakem_C3_N03   (NID_OQS_START + 30)
-#define NID_OQS_ledakem_C3_N04   (NID_OQS_START + 31)
-#define NID_OQS_ledakem_C5_N02   (NID_OQS_START + 32)
+#define NID_OQS_ledakem_C1_N02   0x0219
+#define NID_OQS_ledakem_C1_N03   0x021a
+#define NID_OQS_ledakem_C1_N04   0x021b
+#define NID_OQS_ledakem_C3_N02   0x021c
+#define NID_OQS_ledakem_C3_N03   0x021d
+#define NID_OQS_ledakem_C3_N04   0x021e
+#define NID_OQS_ledakem_C5_N02   0x021f
 /*
-#define NID_OQS_ledakem_C5_N03   (NID_OQS_START + 33)
-#define NID_OQS_ledakem_C5_N04   (NID_OQS_START + 34)
+#define NID_OQS_ledakem_C5_N03
+#define NID_OQS_ledakem_C5_N04
 */
-#define NID_OQS_saber_light_saber (NID_OQS_START + 41)
-#define NID_OQS_saber_saber      (NID_OQS_START + 42)
-#define NID_OQS_saber_fire_saber (NID_OQS_START + 43)
-#endif
+#define NID_OQS_saber_light_saber 0x0228
+#define NID_OQS_saber_saber       0x0229
+#define NID_OQS_saber_fire_saber  0x022a
 /* ADD_MORE_OQS_KEM_HERE (update counter below)*/
-#define NID_OQS_END              (NID_OQS_START + 47)
+ #define NID_OQS_END              0x022a
 
-#define NID_HYBRID_START              (NID_OQS_END + 1)
-#define NID_OQS_p256_KEM_DEFAULT      (NID_HYBRID_START + 0)
-#define NID_OQS_p256_SIKE_503         (NID_HYBRID_START + 1)
-#if !defined(OQS_NIST_BRANCH)
-#define NID_OQS_p256_SIDH_503         (NID_HYBRID_START + 2)
-#endif
-#define NID_OQS_p256_Frodo_640_AES    (NID_HYBRID_START + 3)
-#define NID_OQS_p256_Frodo_640_cshake (NID_HYBRID_START + 4)
-#define NID_OQS_p256_BIKE1_L1         (NID_HYBRID_START + 5)
-#define NID_OQS_p256_BIKE2_L1         (NID_HYBRID_START + 6)
-#define NID_OQS_p256_BIKE3_L1         (NID_HYBRID_START + 7)
-#define NID_OQS_p256_NEWHOPE_512_CCA  (NID_HYBRID_START + 8)
-#if defined(OQS_NIST_BRANCH)
-#define NID_OQS_p256_kyber512         (NID_HYBRID_START + 10)
+#define NID_HYBRID_START           0x02FF
+#define NID_OQS_p256_KEM_DEFAULT   0x02FF
+#define NID_OQS_p256_SIKE_503      0x0300
+#define NID_OQS_p256_SIDH_503      0x0301
+#define NID_OQS_p256_Frodo_640_AES    0x0302
+#define NID_OQS_p256_Frodo_640_cshake 0x0303
+#define NID_OQS_p256_BIKE1_L1         0x0304
+#define NID_OQS_p256_BIKE2_L1         0x0305
+#define NID_OQS_p256_BIKE3_L1         0x0306
+#define NID_OQS_p256_NEWHOPE_512_CCA  0x0307
+#define NID_OQS_p256_kyber512         0x0309
 /* OQS note: ledakem was replaced with LEDAcrypt in round 2; needs an update */
-#define NID_OQS_p256_ledakem_C1_N02   (NID_HYBRID_START + 11)
-#define NID_OQS_p256_ledakem_C1_N03   (NID_HYBRID_START + 12)
-#define NID_OQS_p256_ledakem_C1_N04   (NID_HYBRID_START + 13)
+#define NID_OQS_p256_ledakem_C1_N02   0x030a
+#define NID_OQS_p256_ledakem_C1_N03   0x030b
+#define NID_OQS_p256_ledakem_C1_N04   0x030c
 /*
-#define NID_OQS_p256_saber_light_saber (NID_HYBRID_START + 15)
+#define NID_OQS_p256_saber_light_saber 0x030d
 */
-#endif
 /* ADD_MORE_OQS_KEM_HERE (L1 schemes, update counter below) */
-#define NID_HYBRID_END                (NID_HYBRID_START + 17)
+#define NID_HYBRID_END                0x030c
 
 /* OQS TODO: add L3 algs with p384 curve */
 
 /* Returns true if the nid is for an OQS KEM */
+/* FIXMEOQS: didn't we make the curveid that same as nid; could be simplified a lot 
+             TODO: fix in round2 integration */
 #define IS_OQS_KEM_NID(nid) (nid >= NID_OQS_START && nid <= NID_OQS_END)
 
 /* Returns the curve ID for an OQS KEM NID */

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -170,6 +170,10 @@ static const TLS_GROUP_INFO nid_list[] = {
     {EVP_PKEY_X448, 224, TLS_CURVE_CUSTOM}, /* X448 (30) */
 };
 
+/* FIXMEOQS: the design of oqs_nid_list and oqs_hybrid_nid_list, below, is
+             very fragile; a missing value will offset the alg selection.
+             TODO: revise when integrating round2 schemes. */
+
     /* OQS groups. The values are arbitraty, since the TLS spec does not specify values
        for non finite field and elliptic curve "groups". Security level is classical.
      */
@@ -177,10 +181,8 @@ static const TLS_GROUP_INFO oqs_nid_list[] = {
     {NID_OQS_KEM_DEFAULT, 128, TLS_CURVE_CUSTOM}, /* OQS KEM default (0x01FF) */
     {NID_OQS_SIKE_503, 128, TLS_CURVE_CUSTOM}, /* sike503 (0x0200) */
     {NID_OQS_SIKE_751, 192, TLS_CURVE_CUSTOM}, /* sike751 (0x0201) */
-#if !defined(OQS_NIST_BRANCH)
     {NID_OQS_SIDH_503, 128, TLS_CURVE_CUSTOM}, /* sidh503 (0x0202) */
     {NID_OQS_SIDH_751, 192, TLS_CURVE_CUSTOM}, /* sidh751 (0x0203) */
-#endif
     {NID_OQS_Frodo_640_AES, 128, TLS_CURVE_CUSTOM}, /* frodo640aes (0x0204) */
     {NID_OQS_Frodo_640_cshake, 128, TLS_CURVE_CUSTOM}, /* frodo640cshake (0x0205) */
     {NID_OQS_Frodo_976_AES, 192, TLS_CURVE_CUSTOM}, /* frodo976aes (0x0206) */
@@ -196,8 +198,10 @@ static const TLS_GROUP_INFO oqs_nid_list[] = {
     {NID_OQS_BIKE3_L5, 256, TLS_CURVE_CUSTOM}, /* bike3l5 (0x0210) */
     {NID_OQS_NEWHOPE_512_CCA, 128, TLS_CURVE_CUSTOM}, /* newhope512cca (0x0211) */
     {NID_OQS_NEWHOPE_1024_CCA, 256, TLS_CURVE_CUSTOM}, /* newhope1024cca (0x0212) */
-#if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
+    {0, 0, 0}, /* empty (0x0213) */
+    {0, 0, 0}, /* empty (0x0214) */
+    {0, 0, 0}, /* empty (0x0215) */
     {NID_OQS_kyber512, 128, TLS_CURVE_CUSTOM}, /* kyber512 (0x0216) */
     {NID_OQS_kyber768, 192, TLS_CURVE_CUSTOM}, /* kyber768 (0x0217) */
     {NID_OQS_kyber1024, 256, TLS_CURVE_CUSTOM}, /* kyber1024 (0x0218) */
@@ -208,35 +212,38 @@ static const TLS_GROUP_INFO oqs_nid_list[] = {
     {NID_OQS_ledakem_C3_N03, 192, TLS_CURVE_CUSTOM}, /* ledakem_C3_N03 (0x021d) */
     {NID_OQS_ledakem_C3_N04, 192, TLS_CURVE_CUSTOM}, /* ledakem_C3_N04 (0x021e) */
     {NID_OQS_ledakem_C5_N02, 256, TLS_CURVE_CUSTOM}, /* ledakem_C5_N02 (0x021f) */
-    /* {NID_OQS_ledakem_C5_N03, 256, TLS_CURVE_CUSTOM}, */ /* ledakem_C5_N03 (0x0220) */
-    /* {NID_OQS_ledakem_C5_N04, 256, TLS_CURVE_CUSTOM}, */ /* ledakem_C5_N04 (0x0221) */
+    {0, 0, 0}, /* {NID_OQS_ledakem_C5_N03, 256, TLS_CURVE_CUSTOM}, */ /* ledakem_C5_N03 (0x0220) */
+    {0, 0, 0}, /* {NID_OQS_ledakem_C5_N04, 256, TLS_CURVE_CUSTOM}, */ /* ledakem_C5_N04 (0x0221) */
+    {0, 0, 0}, /* empty (0x0222) */
+    {0, 0, 0}, /* empty (0x0223) */
+    {0, 0, 0}, /* empty (0x0224) */
+    {0, 0, 0}, /* empty (0x0225) */
+    {0, 0, 0}, /* empty (0x0226) */
+    {0, 0, 0}, /* empty (0x0227) */
     {NID_OQS_saber_light_saber, 128, TLS_CURVE_CUSTOM}, /* saber_light_saber (0x0228) */
     {NID_OQS_saber_saber, 192, TLS_CURVE_CUSTOM}, /* saber_saber (0x0229) */
     {NID_OQS_saber_fire_saber, 256, TLS_CURVE_CUSTOM}, /* saber_fire_saber (0x022a) */
-#endif
     /* ADD_MORE_OQS_KEM_HERE */
 };
     /* Hybrid OQS groups. Security level is classical. */
 static const TLS_GROUP_INFO oqs_hybrid_nid_list[] = {
     {NID_OQS_p256_KEM_DEFAULT, 128, TLS_CURVE_CUSTOM}, /* p256 + OQS KEM default hybrid (0x02FF) */
     {NID_OQS_p256_SIKE_503, 128, TLS_CURVE_CUSTOM}, /* p256 + sike503 hybrid (0x0300) */
-#if !defined(OQS_NIST_BRANCH)
     {NID_OQS_p256_SIDH_503, 128, TLS_CURVE_CUSTOM}, /* p256 + sidh503 hybrid (0x0301) */
-#endif
     {NID_OQS_p256_Frodo_640_AES, 128, TLS_CURVE_CUSTOM}, /* p256 + frodo640aes hybrid (0x0302) */
     {NID_OQS_p256_Frodo_640_cshake, 128, TLS_CURVE_CUSTOM}, /* p256 + frodo640cshake hybrid (0x0303) */
     {NID_OQS_p256_BIKE1_L1, 128, TLS_CURVE_CUSTOM}, /* p256 + bike1l1 hybrid (0x0304) */
     {NID_OQS_p256_BIKE2_L1, 128, TLS_CURVE_CUSTOM}, /* p256 + bike2l1 hybrid (0x0305) */
     {NID_OQS_p256_BIKE3_L1, 128, TLS_CURVE_CUSTOM}, /* p256 + bike3l1 hybrid (0x0306) */
     {NID_OQS_p256_NEWHOPE_512_CCA, 128, TLS_CURVE_CUSTOM}, /* p256 + newhope512cca hybrid (0x0307) */
-#if defined(OQS_NIST_BRANCH)
     /* some schemes are disabled because their keys/ciphertext are too big for TLS */
+    {0, 0, 0}, /* empty (0x0308) */
     {NID_OQS_p256_kyber512, 128, TLS_CURVE_CUSTOM}, /* p256 + kyber512 hybrid (0x0309) */
     {NID_OQS_p256_ledakem_C1_N02, 128, TLS_CURVE_CUSTOM}, /* p256 + ledakem_C1_N02 hybrid (0x030a) */
     {NID_OQS_p256_ledakem_C1_N03, 128, TLS_CURVE_CUSTOM}, /* p256 + ledakem_C1_N03 hybrid (0x030b) */
     {NID_OQS_p256_ledakem_C1_N04, 128, TLS_CURVE_CUSTOM}, /* p256 + ledakem_C1_N04 hybrid (0x030c) */
-    /* {NID_OQS_p256_saber_light_saber, 128, TLS_CURVE_CUSTOM}, */ /* p256 + saber_light_saber hybrid (0x030e) */
-#endif
+    {0, 0, 0}, /* empty (0x030d) */
+    {0, 0, 0}, /* {NID_OQS_p256_saber_light_saber, 128, TLS_CURVE_CUSTOM}, */ /* p256 + saber_light_saber hybrid (0x030e) */
     /* ADD_MORE_OQS_KEM_HERE (L1 schemes) */
 };
 


### PR DESCRIPTION
Added missing algs (removed in PR #82) in the oqs nid table to avoid index gaps, and hardcoded the defined nids to satisfy dependent code assumptions.
