### PR TITLE
Regression bug with Frodo in liboqs

### DIFF
--- a/ssl/ssl_locl.h
+++ b/ssl/ssl_locl.h
@@ -697,9 +697,9 @@
   (nid == NID_OQS_SIKE_503        ? OQS_KEM_alg_sike_p503 : \
   (nid == NID_OQS_SIKE_751        ? OQS_KEM_alg_sike_p751 : \
   (nid == NID_OQS_Frodo_640_AES   ? OQS_KEM_alg_frodokem_640_aes : \
-  (nid == NID_OQS_Frodo_640_cshake? OQS_KEM_alg_frodokem_640_cshake : \
+  (nid == NID_OQS_Frodo_640_cshake? OQS_KEM_alg_frodokem_640_shake : \
   (nid == NID_OQS_Frodo_976_AES   ? OQS_KEM_alg_frodokem_976_aes : \
-  (nid == NID_OQS_Frodo_976_cshake? OQS_KEM_alg_frodokem_976_cshake : \
+  (nid == NID_OQS_Frodo_976_cshake? OQS_KEM_alg_frodokem_976_shake : \
   (nid == NID_OQS_BIKE1_L1        ? OQS_KEM_alg_bike1_l1 : \
   (nid == NID_OQS_BIKE1_L3        ? OQS_KEM_alg_bike1_l3 : \
   (nid == NID_OQS_BIKE1_L5        ? OQS_KEM_alg_bike1_l5 : \


### PR DESCRIPTION
Hello, 

oqs_openssl was no longer building for me because of a regression introduced by commit https://github.com/open-quantum-safe/liboqs/commit/19251c41ad44f320b1cc6fc34e5f62c92a30658a , I think.

OQS_KEM_alg_frodokem_640_cshake and OQS_KEM_alg_frodokem_976_cshake used in ssl/ssl_locl.h were no longer defined in liboqs src/kem/kem.c. They were replaced without the "c" in "cshake". After fixing them I was able to build oqs_openssl again. 

Thanks,
PK