### PR TITLE
Modified oqs_bits to return pubkey size in bits rather than bytes.

### DIFF
--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -958,7 +958,7 @@ static int pkey_oqs_digestsign(EVP_MD_CTX *ctx, unsigned char *sig,
     }
 
     if (is_hybrid) {
-      const EVP_MD* classical_md;
+      const EVP_MD *classical_md;
       int digest_len;
       unsigned char digest[SHA512_DIGEST_LENGTH]; /* init with max length */
 
@@ -1050,7 +1050,7 @@ static int pkey_oqs_digestverify(EVP_MD_CTX *ctx, const unsigned char *sig,
 
     if (is_hybrid) {
       EVP_PKEY_CTX *ctx_verify = NULL;
-      const EVP_MD* classical_md;
+      const EVP_MD *classical_md;
       size_t actual_classical_sig_len = 0;
       int digest_len;
       unsigned char digest[SHA512_DIGEST_LENGTH]; /* init with max length */

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -675,7 +675,8 @@ static int oqs_bits(const EVP_PKEY *pkey)
   if (is_oqs_hybrid_alg(oqs_key->nid)) {
     pubkey_len += (SIZE_OF_UINT32 + get_classical_key_len(KEY_TYPE_PUBLIC, get_classical_nid(oqs_key->nid)));
   }
-  return pubkey_len;
+  /* return size in bits */
+  return 8 * pubkey_len;
 }
 
 static int oqs_security_bits(const EVP_PKEY *pkey)

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -676,7 +676,7 @@ static int oqs_bits(const EVP_PKEY *pkey)
     pubkey_len += (SIZE_OF_UINT32 + get_classical_key_len(KEY_TYPE_PUBLIC, get_classical_nid(oqs_key->nid)));
   }
   /* return size in bits */
-  return 8 * pubkey_len;
+  return CHAR_BIT * pubkey_len;
 }
 
 static int oqs_security_bits(const EVP_PKEY *pkey)
@@ -958,7 +958,7 @@ static int pkey_oqs_digestsign(EVP_MD_CTX *ctx, unsigned char *sig,
     }
 
     if (is_hybrid) {
-      EVP_MD* classical_md = NULL;
+      const EVP_MD* classical_md;
       int digest_len;
       unsigned char digest[SHA512_DIGEST_LENGTH]; /* init with max length */
 
@@ -1050,7 +1050,7 @@ static int pkey_oqs_digestverify(EVP_MD_CTX *ctx, const unsigned char *sig,
 
     if (is_hybrid) {
       EVP_PKEY_CTX *ctx_verify = NULL;
-      EVP_MD* classical_md = NULL;
+      const EVP_MD* classical_md;
       size_t actual_classical_sig_len = 0;
       int digest_len;
       unsigned char digest[SHA512_DIGEST_LENGTH]; /* init with max length */


### PR DESCRIPTION
Modified oqs_bits to return pubkey size in bits rather than bytes. Fixes #90.