### PR TITLE
Remove /WX from CFLAGS for VC-WIN32 build

### DIFF
--- a/Configurations/10-main.conf
+++ b/Configurations/10-main.conf
@@ -1313,7 +1313,6 @@ my %targets = (
     "VC-WIN32" => {
         inherit_from     => [ "VC-noCE-common", asm("x86_asm"),
                               sub { $disabled{shared} ? () : "uplink_common" } ],
-        CFLAGS           => add("/WX"),
         AS               => sub { vc_win32_info()->{AS} },
         ASFLAGS          => sub { vc_win32_info()->{ASFLAGS} },
         asoutflag        => sub { vc_win32_info()->{asoutflag} },


### PR DESCRIPTION
crypto\ec\oqs_meth.c generates warnings:

crypto\ec\oqs_meth.c(611): error C2220: warning treated as error - no 'object' file generated
crypto\ec\oqs_meth.c(611): warning C4018: '>': signed/unsigned mismatch
crypto\ec\oqs_meth.c(1006): warning C4018: '>': signed/unsigned mismatch

VC-WIN32 includes /WX and that causes a build break. VC-WIN64A does not use /WX, and this change removes it from VC-WIN32 to fix the build.

Official OpenSSL also has this differing behavior between VC-WIN32 and VC-WIN64A. There may be a reason for this that may necessitate fixing the warnings directly, but this unbreaks the build for now.