### PR TITLE
; deleted in #define

### DIFF
--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -561,7 +561,7 @@ int EVP_MD_CTX_ctrl(EVP_MD_CTX *ctx, int cmd, int p1, void *p2);
 EVP_MD_CTX *EVP_MD_CTX_new(void);
 int EVP_MD_CTX_reset(EVP_MD_CTX *ctx);
 void EVP_MD_CTX_free(EVP_MD_CTX *ctx);
-# define EVP_MD_CTX_create()     EVP_MD_CTX_new();
+# define EVP_MD_CTX_create()     EVP_MD_CTX_new()
 # define EVP_MD_CTX_init(ctx)    EVP_MD_CTX_reset((ctx))
 # define EVP_MD_CTX_destroy(ctx) EVP_MD_CTX_free((ctx))
 __owur int EVP_MD_CTX_copy_ex(EVP_MD_CTX *out, const EVP_MD_CTX *in);


### PR DESCRIPTION
Correction on #139 : Sorry for not spotting this extraneous ";" earlier... It breaks at least the new CMS code -- and arguably could break other "openssl users", too.
