### PR TITLE
No paddingtest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ localCheckout: &localCheckout
         command: .circleci/git_no_checkin_in_last_day.sh || (cd oqs_test && scripts/build_openssl.sh)
     - run:
         name: Run unit tests
-        command: mkdir -p oqs_test/test-results && .circleci/git_no_checkin_in_last_day.sh || (cd oqs_test && LD_LIBRARY_PATH="$(dirname $PWD);$(dirname $PWD)/oqs/lib" python3 -m nose --rednose --verbose --with-xunit --xunit-file=test-results/nosetests.xml)
+        command: mkdir -p oqs_test/test-results && .circleci/git_no_checkin_in_last_day.sh || (LD_LIBRARY_PATH="$(pwd):$(pwd)/oqs/lib" make test && cd oqs_test && LD_LIBRARY_PATH="$(dirname $PWD);$(dirname $PWD)/oqs/lib" python3 -m nose --rednose --verbose --with-xunit --xunit-file=test-results/nosetests.xml)
     - store_test_results: # Note that this command will fail when running CircleCI locally, that is expected behaviour
         path: oqs_test/test-results
 
@@ -90,6 +90,15 @@ jobs:
       LIBOQS: master
       OPENSSL: 111
       LIBTYPE: shared
+  ubuntu-bionic-x86_64-shared-noconn:
+    <<: *openssljob
+    environment:
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+      ARCH: x64
+      LIBOQS: master
+      OPENSSL: 111
+      LIBTYPE: shared
+      SKIP_TESTS: connection
   macOS-shared-noconn:
     <<: *macopenssljob
     environment:
@@ -110,6 +119,7 @@ workflows:
   build:
     jobs:
       - macOS-shared-noconn    
+      - ubuntu-bionic-x86_64-shared-noconn
       - ubuntu-bionic-x86_64-noconn
   nightly:
     triggers:

--- a/test/clienthellotest.c
+++ b/test/clienthellotest.c
@@ -27,7 +27,7 @@
 
 #define CLIENT_VERSION_LEN      2
 
-#define TOTAL_NUM_TESTS                        2// 4 see OQS note above
+#define TOTAL_NUM_TESTS                        1// 4 see OQS note above
 
 /*
  * Test that explicitly setting ticket data results in it appearing in the
@@ -35,7 +35,7 @@
  */
 #define TEST_SET_SESSION_TICK_DATA_VER_NEG      0
 /* Enable padding and make sure ClientHello is long enough to require it */
-#define TEST_ADD_PADDING                        1
+#define TEST_ADD_PADDING                       -3  // OQS creates ClientHello longer than this test ever envisaged
 /* Enable padding and make sure ClientHello is short enough to not need it */
 #define TEST_PADDING_NOT_NEEDED                 -1 // see OQS note above
 /*


### PR DESCRIPTION
Fixes #150. `make test` passes completely when liboqs/openssl are built static or shared: These tests now also added to CI testing to ensure #150 (or similar) doesn't happen again.
