### PR TITLE
followed liboqs refactoring

### DIFF
--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -268,7 +268,7 @@ const char *OQSKEM_options(void)
 {
     const char* OQSKEMALGS = "OQS KEM build : ";
     int offset;
-// For some reason we cannot assume OQS_COMPILE_CFLAGS to be present...
+// TODO: Revisit which OQS_COMPILE_FLAGS to show
 #ifdef OQS_COMPILE_CFLAGS
     char* result =  OPENSSL_zalloc(strlen(OQS_COMPILE_CFLAGS)+OQS_KEM_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSKEMALGS, offset = strlen(OQSKEMALGS));
@@ -299,7 +299,7 @@ const char *OQSSIG_options(void)
 {
     const char* OQSSIGALGS = "OQS SIG build : ";
     int offset;
-// For some reason we cannot assume OQS_COMPILE_CFLAGS to be present...
+// TODO: Revisit which OQS_COMPILE_FLAGS to show
 #ifdef OQS_COMPILE_CFLAGS
     char* result =  OPENSSL_zalloc(strlen(OQS_COMPILE_CFLAGS)+OQS_OPENSSL_SIG_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSSIGALGS, offset = strlen(OQSSIGALGS));

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -268,10 +268,17 @@ const char *OQSKEM_options(void)
 {
     const char* OQSKEMALGS = "OQS KEM build : ";
     int offset;
+// For some reason we cannot assume OQS_COMPILE_CFLAGS to be present...
+#ifdef OQS_COMPILE_CFLAGS
     char* result =  OPENSSL_zalloc(strlen(OQS_COMPILE_CFLAGS)+OQS_KEM_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSKEMALGS, offset = strlen(OQSKEMALGS));
     memcpy(result+offset, OQS_COMPILE_CFLAGS, strlen(OQS_COMPILE_CFLAGS));
     offset += strlen(OQS_COMPILE_CFLAGS);
+#else 
+    char* result =  OPENSSL_zalloc(OQS_KEM_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
+    memcpy(result, OQSKEMALGS, offset = strlen(OQSKEMALGS));
+#endif
+
     result[offset++]='-';
     int i;
     for (i=0; i<OQS_KEM_algs_length;i++) {
@@ -292,10 +299,17 @@ const char *OQSSIG_options(void)
 {
     const char* OQSSIGALGS = "OQS SIG build : ";
     int offset;
+// For some reason we cannot assume OQS_COMPILE_CFLAGS to be present...
+#ifdef OQS_COMPILE_CFLAGS
     char* result =  OPENSSL_zalloc(strlen(OQS_COMPILE_CFLAGS)+OQS_OPENSSL_SIG_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSSIGALGS, offset = strlen(OQSSIGALGS));
     memcpy(result+offset, OQS_COMPILE_CFLAGS, strlen(OQS_COMPILE_CFLAGS));
     offset += strlen(OQS_COMPILE_CFLAGS);
+#else
+    char* result =  OPENSSL_zalloc(OQS_OPENSSL_SIG_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
+    memcpy(result, OQSSIGALGS, offset = strlen(OQSSIGALGS));
+#endif
+
     result[offset++]='-';
     int i;
     for (i=0; i<OQS_OPENSSL_SIG_algs_length;i++) {

--- a/oqs_test/scripts/build_liboqs.sh
+++ b/oqs_test/scripts/build_liboqs.sh
@@ -13,12 +13,6 @@ OPENSSL_DIR=${OPENSSL_DIR:-"`pwd`/../oqs"}
 
 cd tmp/liboqs
 
-# temporary cludge to avoid CPU features to be build in that executors may not have:
-# TBD XXX replace with dynamic CPU feature detection at runtime!!! XXX TBD
-if [ "x${CIRCLECI}" == "xtrue" ]; then
-sed -i -e "s/x86/t86/g" .CMake/cpu-extensions.cmake
-fi
-
 rm -rf build
 mkdir build && cd build
 


### PR DESCRIPTION
Following the liboqs cmake refactoring (incl. default build w/o optimisations), one hack in liboqs-build (in openssl's test-build script) became unnecessary, so is removed. Also, the presence of the compile-time define `OQS_COMPILE_CFLAGS` is now considered optional. @xvzcf : If you could consider adding this back in, that'd be great: I used it to inform `openssl speed` users of the compile time options passed not just to openssl but also of those to liboqs -- which arguably has the biggest impact on speed/performance.