### PR TITLE
add OQS algs to auto-run list in speed

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1980,6 +1980,14 @@ int speed_main(int argc, char **argv)
         for (loop = 0; loop < OSSL_NELEM(eddsa_doit); loop++)
             eddsa_doit[loop] = 1;
 #endif
+#ifndef OPENSSL_NO_OQSKEM
+    	for (i = 0; i < OQSKEM_NUM; i++) 
+            oqskem_doit[i] = 1;
+#endif
+#ifndef OPENSSL_NO_OQSSIG
+    	for (i = 0; i < OQSSIG_NUM; i++) 
+            oqssig_doit[i] = 1;
+#endif
     }
     for (i = 0; i < ALGOR_NUM; i++)
         if (doit[i])


### PR DESCRIPTION
Completes issue #35 : With this PR, `openssl speed` (without further parameters) also tests performance of all OQS algorithms automatically (as it does for classic crypto if called this way). Additional testing was not added for this as a) that would extend test time inappropriately and b) is not exactly essential functionality.