### PR TITLE
Option to explicitly configure default algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,16 @@ on **Ubuntu**, run:
 
 The fork can also be built as a set of shared libraries by specifying `shared` instead of `no-shared` in the above commands; We have used `no-shared` to avoid having to get the libraries in the right place for the runtime linker.
 
+#### Build options
+
+##### Default algorithms announced
+
+By default, this OpenSSL is built to only announce 128-bit strength QSC hybrid KEM algorithms in the initial TLS handshake (EC groups announced extension). This algorithm set can be changed to an arbitrary desired mix at build time by setting the variable `OQS_DEFAULT_GROUPS` to a colon-separated list of [KEM algorithms supported](#key-exchange), e.g., running 
+```
+./Configure no-shared linux-x86_64 -DOQS_DEFAULT_GROUPS=\"p256_kyber768:X25519:newhope1024cca\" -lm
+```
+This is the same syntax that can be used at runtime to select the announced algorithms (by setting the `-curves` parameter with clients supporting this option, e.g., `openssl s_client` or `openssl s_server`). 
+
 ### Running
 
 #### TLS demo

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -360,8 +360,17 @@ void tls1_get_supported_groups(SSL *s, const uint16_t **pgroups,
 
     default:
         if (s->ext.supportedgroups == NULL) {
+#ifndef OQS_DEFAULT_GROUPS
             *pgroups = eccurves_default;
             *pgroupslen = OSSL_NELEM(eccurves_default);
+#else
+#define STRINGIZE(x) #x
+#define STRINGIZE_VALUE_OF(x) STRINGIZE(x)
+            if (!tls1_set_groups_list(pgroups, pgroupslen, STRINGIZE_VALUE_OF(OQS_DEFAULT_GROUPS))) {
+               *pgroups = eccurves_default;
+               *pgroupslen = OSSL_NELEM(eccurves_default);
+            }
+#endif
         } else {
             *pgroups = s->ext.supportedgroups;
             *pgroupslen = s->ext.supportedgroups_len;


### PR DESCRIPTION
This allows reducing/setting the list of default announced KEMs to something other than 128-bit hybrid algs. This is more flexible, short to specify (only one new #define) and in line with standard openssl syntax (`-curves` parameter).

Tests have not been added as this is a non-default, Configure-time option which would demand a full new test matrix if thoroughly tested.

Therefore only a Draft-PR until review feedback is received.

##### Checklist
- [x] documentation is added or updated
- [ ] tests are added or updated
