### PR TITLE
Increase max size for signatures in speed.c

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -213,7 +213,10 @@ static int do_multi(int multi, int size_num);
 #endif
 
 static const int lengths_list[] = {
-    16, 64, 256, 1024, 8 * 1024, 16 * 1024
+  16, 64, 256, 1024, 8 * 1024, 16 * 1024
+#ifndef OPENSSL_NO_OQSSIG
+  , 35000 // OQS note: need larger buffer for OQS signatures
+#endif
 };
 static const int *lengths = lengths_list;
 

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3762,6 +3762,7 @@ int speed_main(int argc, char **argv)
 
  end:
     ERR_print_errors(bio_err);
+    if (getenv("OPENSSL_NO_CLEANUP")) goto realend;
     for (i = 0; i < loopargs_len; i++) {
         OPENSSL_free(loopargs[i].buf_malloc);
         OPENSSL_free(loopargs[i].buf2_malloc);

--- a/apps/speed.c
+++ b/apps/speed.c
@@ -3762,7 +3762,6 @@ int speed_main(int argc, char **argv)
 
  end:
     ERR_print_errors(bio_err);
-    if (getenv("OPENSSL_NO_CLEANUP")) goto realend;
     for (i = 0; i < loopargs_len; i++) {
         OPENSSL_free(loopargs[i].buf_malloc);
         OPENSSL_free(loopargs[i].buf2_malloc);

--- a/oqs_test/scripts/do_openssl-speed.sh
+++ b/oqs_test/scripts/do_openssl-speed.sh
@@ -23,9 +23,7 @@ if [ `uname` == "Darwin" ]; then
 # On OSX, only test one alg that doesn't cause memory problems:
    apps/openssl speed -seconds 1 dilithium2
 else
-   apps/openssl speed -seconds 1 oqssig
-fi
-if [ $? -ne 0 ]; then
-   exit -1
+# Disabling cleanup on Linux because of picnic-induced memory glitch:
+   OPENSSL_NO_CLEANUP=1 apps/openssl speed -seconds 1 oqssig
 fi
 

--- a/oqs_test/scripts/do_openssl-speed.sh
+++ b/oqs_test/scripts/do_openssl-speed.sh
@@ -23,7 +23,9 @@ if [ `uname` == "Darwin" ]; then
 # On OSX, only test one alg that doesn't cause memory problems:
    apps/openssl speed -seconds 1 dilithium2
 else
-# Disabling cleanup on Linux because of picnic-induced memory glitch:
-   OPENSSL_NO_CLEANUP=1 apps/openssl speed -seconds 1 oqssig
+   apps/openssl speed -seconds 1 oqssig
+fi
+if [ $? -ne 0 ]; then
+   exit -1
 fi
 


### PR DESCRIPTION
Increases max signature sizes for speed tests to 35000 (enough for picnicl1fs). Test code is hard to read, but it uses the last value of `lengths_list` array to allocate the signature buffer in the OQS tests. We'll need to update this value as we add algs with larger sigs.

Fixes issue #159.