### PR TITLE
Addresses #122

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1851,31 +1851,31 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_OQSKEM
         if (strcmp(*argv, "oqskem") == 0) {
             for (loop = 0; loop < OSSL_NELEM(oqskem_doit); loop++)
-                oqskem_doit[loop] = 1;
+                oqskem_doit[loop] = OQS_KEM_alg_is_enabled(OQS_KEM_alg_identifier(loop));
             continue;
         }
         if (found(*argv, oqskem_choices, &i)) {
-            oqskem_doit[i] = 2;
+            oqskem_doit[i] = 2*OQS_KEM_alg_is_enabled(OQS_KEM_alg_identifier(i));
             continue;
         }
 #endif
 #ifndef OPENSSL_NO_OQSSIG
         if (strcmp(*argv, "oqssig") == 0) {
             for (loop = 0; loop < OSSL_NELEM(oqssig_doit); loop++)
-                oqssig_doit[loop] = 1;
+                oqssig_doit[loop] = OQS_SIG_alg_is_enabled(OQS_SIG_alg_identifier(loop));
             continue;
         }
         if (found(*argv, oqssig_choices, &i)) {
-            oqssig_doit[i] = 2;
+            oqssig_doit[i] = 2*OQS_SIG_alg_is_enabled(OQS_SIG_alg_identifier(i));
             continue;
         }
 #endif
         BIO_printf(bio_err, "%s: Unknown algorithm %s\n", prog, *argv);
 #ifndef OPENSSL_NO_OQSKEM
-        BIO_printf(bio_err, "OQSKEM config: %s", OQSKEM_options());
+        BIO_printf(bio_err, "OQSKEM config: %s\n", OQSKEM_options());
 #endif
 #ifndef OPENSSL_NO_OQSSIG
-        BIO_printf(bio_err, "OQSSIG config: %s", OQSSIG_options());
+        BIO_printf(bio_err, "OQSSIG config: %s\n", OQSSIG_options());
 #endif
         goto end;
     }
@@ -1980,11 +1980,11 @@ int speed_main(int argc, char **argv)
 #endif
 #ifndef OPENSSL_NO_OQSKEM
     	for (i = 0; i < OQSKEM_NUM; i++) 
-            oqskem_doit[i] = 1;
+            oqskem_doit[i] = OQS_KEM_alg_is_enabled(OQS_KEM_alg_identifier(i));
 #endif
 #ifndef OPENSSL_NO_OQSSIG
     	for (i = 0; i < OQSSIG_NUM; i++) 
-            oqssig_doit[i] = 1;
+            oqssig_doit[i] = OQS_SIG_alg_is_enabled(OQS_SIG_alg_identifier(i));
 #endif
     }
     for (i = 0; i < ALGOR_NUM; i++)

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -266,15 +266,16 @@ static int get_classical_sig_len(int classical_id)
  */
 const char *OQSKEM_options(void)
 {
-    const char* OQSKEMALGS = "OQS KEM build : ";
     int offset;
 // TODO: Revisit which OQS_COMPILE_FLAGS to show
 #ifdef OQS_COMPILE_CFLAGS
+    const char* OQSKEMALGS = "OQS KEM build : ";
     char* result =  OPENSSL_zalloc(strlen(OQS_COMPILE_CFLAGS)+OQS_KEM_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSKEMALGS, offset = strlen(OQSKEMALGS));
     memcpy(result+offset, OQS_COMPILE_CFLAGS, strlen(OQS_COMPILE_CFLAGS));
     offset += strlen(OQS_COMPILE_CFLAGS);
 #else 
+    const char* OQSKEMALGS = "";
     char* result =  OPENSSL_zalloc(OQS_KEM_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSKEMALGS, offset = strlen(OQSKEMALGS));
 #endif
@@ -282,11 +283,13 @@ const char *OQSKEM_options(void)
     result[offset++]='-';
     int i;
     for (i=0; i<OQS_KEM_algs_length;i++) {
-       int l = strlen(OQS_KEM_alg_identifier(i));
-       memcpy(result+offset, OQS_KEM_alg_identifier(i), l);
-       if (i<OQS_KEM_algs_length-1) {
-          result[offset+l]=',';
-          offset = offset+l+1;
+       if (OQS_KEM_alg_is_enabled(OQS_KEM_alg_identifier(i))) {
+           int l = strlen(OQS_KEM_alg_identifier(i));
+           memcpy(result+offset, OQS_KEM_alg_identifier(i), l);
+           if (i<OQS_KEM_algs_length-1) {
+              result[offset+l]=',';
+              offset = offset+l+1;
+           }
        }
     }
     return result;
@@ -297,15 +300,16 @@ const char *OQSKEM_options(void)
  */
 const char *OQSSIG_options(void)
 {
-    const char* OQSSIGALGS = "OQS SIG build : ";
     int offset;
 // TODO: Revisit which OQS_COMPILE_FLAGS to show
 #ifdef OQS_COMPILE_CFLAGS
+    const char* OQSSIGALGS = "OQS SIG build : ";
     char* result =  OPENSSL_zalloc(strlen(OQS_COMPILE_CFLAGS)+OQS_OPENSSL_SIG_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSSIGALGS, offset = strlen(OQSSIGALGS));
     memcpy(result+offset, OQS_COMPILE_CFLAGS, strlen(OQS_COMPILE_CFLAGS));
     offset += strlen(OQS_COMPILE_CFLAGS);
 #else
+    const char* OQSSIGALGS = "";
     char* result =  OPENSSL_zalloc(OQS_OPENSSL_SIG_algs_length*40); // OK, a bit pessimistic but this will be removed very soon...
     memcpy(result, OQSSIGALGS, offset = strlen(OQSSIGALGS));
 #endif
@@ -314,11 +318,13 @@ const char *OQSSIG_options(void)
     int i;
     for (i=0; i<OQS_OPENSSL_SIG_algs_length;i++) {
        const char* name = OBJ_nid2sn(oqssl_sig_nids_list[i]);
-       int l = strlen(name);
-       memcpy(result+offset, name, l);
-       if (i<OQS_OPENSSL_SIG_algs_length-1) {
-          result[offset+l]=',';
-          offset = offset+l+1;
+       if (OQS_SIG_alg_is_enabled(get_oqs_alg_name(oqssl_sig_nids_list[i]))) {
+           int l = strlen(name);
+           memcpy(result+offset, name, l);
+           if (i<OQS_OPENSSL_SIG_algs_length-1) {
+              result[offset+l]=',';
+              offset = offset+l+1;
+           }
        }
     }
     return result;

--- a/ssl/statem/extensions_clnt.c
+++ b/ssl/statem/extensions_clnt.c
@@ -635,10 +635,10 @@ static int add_key_share(SSL *s, WPACKET *pkt, unsigned int curve_id)
 
       oqs_cleanup:
         if (has_error) {
-          OQS_MEM_secure_free(s->s3->tmp.oqs_kem_client, s->s3->tmp.oqs_kem->length_secret_key);
+          if (s->s3->tmp.oqs_kem_client) OQS_MEM_secure_free(s->s3->tmp.oqs_kem_client, s->s3->tmp.oqs_kem->length_secret_key);
           OQS_MEM_insecure_free(oqs_encoded_point);
           s->s3->tmp.oqs_kem_client = NULL;
-          OQS_KEM_free(s->s3->tmp.oqs_kem);
+          if (s->s3->tmp.oqs_kem) OQS_KEM_free(s->s3->tmp.oqs_kem);
           s->s3->tmp.oqs_kem = NULL;
           return 0;
         }

--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -557,8 +557,13 @@ static int nid_cb(const char *elem, int len, void *arg)
     memcpy(etmp, elem, len);
     etmp[len] = 0;
     nid = EC_curve_nist2nid(etmp);
-    if (nid == NID_undef)
+    if (nid == NID_undef) {
         nid = OBJ_sn2nid(etmp);
+        if (nid == NID_undef) fprintf(stderr, "Warning: Algorithm name '%s' unknown. Check https://github.com/open-quantum-safe/openssl#supported-algorithms\n", etmp);
+        else {
+             if (!OQS_KEM_alg_is_enabled(etmp)) fprintf(stderr, "Warning: Algorithm '%s' is not enabled in liboqs. \n", etmp);
+        }
+    }
     if (nid == NID_undef)
         nid = OBJ_ln2nid(etmp);
     if (nid == NID_undef)


### PR DESCRIPTION
As discussed in #122  not a perfect solution but probably the best doable at this time.

Also fixes a (probable) memory de-allocation problem.

Only additional documentation: `openssl speed` and `openssl s_client/s_server` output in case of unsupported algorithms requested. CI testing not really doable as discussed in [the issue](https://github.com/open-quantum-safe/openssl/issues/122#issuecomment-624288897). 

