### PR TITLE
corrected SIG enablement checks (#122)

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -1862,11 +1862,11 @@ int speed_main(int argc, char **argv)
 #ifndef OPENSSL_NO_OQSSIG
         if (strcmp(*argv, "oqssig") == 0) {
             for (loop = 0; loop < OSSL_NELEM(oqssig_doit); loop++)
-                oqssig_doit[loop] = OQS_SIG_alg_is_enabled(OQS_SIG_alg_identifier(loop));
+                oqssig_doit[loop] = OQS_SIG_alg_is_enabled(get_oqs_alg_name(oqssl_sig_nids_list[loop]));
             continue;
         }
         if (found(*argv, oqssig_choices, &i)) {
-            oqssig_doit[i] = 2*OQS_SIG_alg_is_enabled(OQS_SIG_alg_identifier(i));
+            oqssig_doit[i] = 2*OQS_SIG_alg_is_enabled(get_oqs_alg_name(oqssl_sig_nids_list[i]));
             continue;
         }
 #endif
@@ -1984,7 +1984,7 @@ int speed_main(int argc, char **argv)
 #endif
 #ifndef OPENSSL_NO_OQSSIG
     	for (i = 0; i < OQSSIG_NUM; i++) 
-            oqssig_doit[i] = OQS_SIG_alg_is_enabled(OQS_SIG_alg_identifier(i));
+            oqssig_doit[i] = OQS_SIG_alg_is_enabled(get_oqs_alg_name(oqssl_sig_nids_list[i]));
 #endif
     }
     for (i = 0; i < ALGOR_NUM; i++)

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -111,7 +111,7 @@ int* get_oqssl_sig_nids() {
 /*
  * Maps OpenSSL NIDs to OQS IDs
  */
-static char* get_oqs_alg_name(int openssl_nid)
+char* get_oqs_alg_name(int openssl_nid)
 {
   switch (openssl_nid)
   {
@@ -464,6 +464,8 @@ static int oqs_key_init(OQS_KEY **p_oqs_key, int nid, oqs_key_type_t keytype) {
       goto err;
     }
     oqs_key->nid = nid;
+    if (!OQS_SIG_alg_is_enabled(oqs_alg_name))
+      fprintf(stderr, "Warning: OQS algorithm '%s' not enabled.\n", oqs_alg_name);
     oqs_key->s = OQS_SIG_new(oqs_alg_name);
     if (oqs_key->s == NULL) {
       /* TODO: Perhaps even check if the alg is available earlier in the stack. */

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -90,6 +90,7 @@ const char *OQSKEM_options(void);
 const char *OQSSIG_options(void);
 int oqs_size(const EVP_PKEY *pkey);
 int* get_oqssl_sig_nids();
+char* get_oqs_alg_name(int openssl_nid);
 
 
 #ifdef  __cplusplus


### PR DESCRIPTION
Amendment to fix for #122: Added warning to SIG usage disabled in liboqs and corrected checking for SIG enablement in `openssl speed`.