### PR TITLE
Dilithium OID documentation added

### DIFF
--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -274,10 +274,21 @@ sigs:
                     "pretty_name": "RSA3072",
                     "oid": "1.3.9999.1.3"}]
   -
+    # OID scheme for hybrid variants of Dilithium:
     # iso (1)
     # identified-organization (3)
     # reserved (9999)
     # dilithium (2)
+    # OID scheme for plain Dilithium:
+    # iso (1)
+    # identified-organization (3)
+    # dod (6)
+    # internet (1)
+    # private (4)
+    # enterprise (1)
+    # IBM (2)
+    # qsc (267)
+    # Dilithium-raw (6)
     variants:
       -
         name: "dilithium2"


### PR DESCRIPTION
As per request by @xvzcf added OID documentation for dilithium

(no code change, CCI did run regardless: https://circleci.com/gh/baentsch/workflows/openssl/tree/mb-oidcomments)