### PR TITLE
fixing speed crash in AES

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -216,7 +216,7 @@ static int do_multi(int multi, int size_num);
 static const int lengths_list[] = {
   16, 64, 256, 1024, 8 * 1024, 16 * 1024
 #ifndef OPENSSL_NO_OQSSIG
-  , 35000 // OQS note: need larger buffer for OQS signatures
+  , 35 * 1024 // OQS note: need larger buffer for OQS signatures
 #endif
 };
 static const int *lengths = lengths_list;


### PR DESCRIPTION
Fixes: 

> OpenSSL internal error: assertion failed: (length % AES_BLOCK_SIZE)

Tests ran OK at https://circleci.com/gh/baentsch/openssl/tree/mb-fixaesspeed

