### PR TITLE
properly installing versioned shared liboqs

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -679,13 +679,6 @@ install_dev: install_runtime_libs
 	@chmod 644 "$(DESTDIR)$(libdir)/pkgconfig/openssl.pc"
 	@$(ECHO) "install liboqs.pc -> $(DESTDIR)$(libdir)/pkgconfig/liboqs.pc"
 	@cp liboqs.pc $(DESTDIR)$(libdir)/pkgconfig
-ifneq (,$(wildcard oqs/lib/liboqs.a))
-	@install oqs/lib/liboqs.a $(DESTDIR)$(libdir)
-endif
-ifneq (,$(wildcard oqs/lib/liboqs.so.0.0.0))
-	@install oqs/lib/liboqs.so.0.0.0 $(DESTDIR)$(libdir)
-	@cd $(DESTDIR)$(libdir) && ln -sf liboqs.so.0.0.0 liboqs.so && ln -sf liboqs.so.0.0.0 liboqs.so.0 && cd -
-endif
 	@chmod 644 $(DESTDIR)$(libdir)/pkgconfig/liboqs.pc
 
 uninstall_dev: uninstall_runtime_libs
@@ -787,6 +780,19 @@ install_runtime_libs: build_libs
 		      "$(DESTDIR)$(libdir)/$$fn"; \
 		: {- output_on() if windowsdll(); "" -}; \
 	done
+ifneq (,$(wildcard oqs/lib/liboqs.a))
+	@install oqs/lib/liboqs.a $(DESTDIR)$(libdir)
+endif
+ifneq (,$(wildcard oqs/lib/liboqs.so.0*))
+	@set -e; for i in oqs/lib/liboqs.so.0.*; do \
+		fn=`basename $$i`; \
+		$(ECHO) "install oqs/lib/$$fn $(DESTDIR)$(libdir)"; \
+		$(ECHO) "cd $(DESTDIR)$(libdir) && ln -sf $$fn liboqs.so && ln -sf $$fn liboqs.so.0 && cd -"; \
+		install oqs/lib/$$fn $(DESTDIR)$(libdir); \
+		cd $(DESTDIR)$(libdir) && ln -sf $$fn liboqs.so && ln -sf $$fn liboqs.so.0 && cd -; \
+	done
+endif
+
 
 install_programs: install_runtime_libs build_programs
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)


### PR DESCRIPTION
Follow-up to (https://github.com/open-quantum-safe/liboqs/pull/767) properly versioning `liboqs` with generic and properly located openssl install directives. 

Tests ran OK at https://circleci.com/gh/baentsch/openssl/tree/mb-installoqsso 
