### PR TITLE
Redirect boringssl submodule url to open-quantum-safe fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "boringssl"]
 	path = boringssl
-	url = https://boringssl.googlesource.com/boringssl
+	url = https://github.com/open-quantum-safe/boringssl
 
 [submodule "pyca.cryptography"]
 	path = pyca-cryptography


### PR DESCRIPTION
Commit 2faa797e36a697be8199da20322f58b85aacf86d updated the boringssl submodule to a commit that only exists in the open-quantum-safe/boringssl fork, but the `.gitmodules` file still references the official BoringSSL repo. This causes `git submodule update` or `git clone --recurse-submodules` to now fail. This change clones the submodule from OQS's fork instead, where the commit exists.