### PR TITLE
Always create $(DESTDIR)/lib during make install, even on Windows

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -757,9 +757,8 @@ install_runtime: install_programs
 
 install_runtime_libs: build_libs
 	@[ -n "$(INSTALLTOP)" ] || (echo INSTALLTOP should not be empty; exit 1)
-	@ : {- output_off() if windowsdll(); "" -}
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(libdir)"
-	@ : {- output_on() if windowsdll(); output_off() unless windowsdll(); "" -}
+	@ : {- output_off() unless windowsdll(); "" -}
 	@$(PERL) $(SRCDIR)/util/mkdir-p.pl "$(DESTDIR)$(INSTALLTOP)/bin"
 	@ : {- output_on() unless windowsdll(); "" -}
 	@$(ECHO) "*** Installing runtime libraries"


### PR DESCRIPTION
Cross-compiling for Windows deposits binaries in bin, not lib.

Commit 72ea3e9 added rules to copy `liboqs.a` to OpenSSL's lib directory for development purposes, but when cross-compiling for Windows, lib hasn't been created yet.

As a result, during `make install`, `liboqs.a` ends up copied and named `lib` in $(DESTDIR). This later causes a failure when it tries to create a directory there called `lib` only to find a file exists with that name.

This commit causes `lib` to always be created in the `install_runtime_libs` recipe, and `liboqs.a` ends up in the right place. The `mkdir-p.pl` script doesn't fail if it tries to create a directory that already exists as a directory, and `make install` succeeds.