### PR TITLE
All CI tests should pass now.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ localCheckout: &localCheckout
               )
         - run:
             name: Clone liboqs
-            command: ./oqs-scripts/clone_liboqs.sh # unconditional checkout to test for changes there
+            command: env LIBOQS_BRANCH=0.3.0 ./oqs-scripts/clone_liboqs.sh # unconditional checkout to test for changes there
         - run:
             name: Build liboqs
             command: .circleci/git_no_checkin_in_last_day.sh || ./oqs-scripts/build_liboqs.sh
@@ -70,7 +70,7 @@ localCheckout: &localCheckout
     - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
     - run:
         name: Clone liboqs and BoringSSL
-        command: ./oqs-scripts/clone_liboqs.sh && ./oqs-scripts/clone_boringssl.sh
+        command: (env LIBOQS_BRANCH=0.3.0 ./oqs-scripts/clone_liboqs.sh) && ./oqs-scripts/clone_boringssl.sh
     - run:
         name: Build liboqs
         command: .circleci/git_no_checkin_in_last_day.sh || ./oqs-scripts/build_liboqs.sh


### PR DESCRIPTION
I forgot to update the macOS and BoringSSL-interop jobs in CircleCI. 

The complete CI test suite results can be found here: https://app.circleci.com/pipelines/github/open-quantum-safe/openssl/437/workflows/e9cf2b53-67bf-461d-a338-da8c9c37717f