### PR TITLE
openssl: Add count of liboqs pq and hybrid curves to MAX_CURVES_LIST

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -625,7 +625,9 @@ int tls1_set_groups(uint16_t **pext, size_t *pextlen,
     return 1;
 }
 
-# define MAX_CURVELIST   OSSL_NELEM(nid_list)
+# define MAX_CURVELIST   (OSSL_NELEM(nid_list) + \
+		          OSSL_NELEM(oqs_nid_list) + \
+			  OSSL_NELEM(oqs_hybrid_nid_list))
 
 typedef struct {
     size_t nidcnt;


### PR DESCRIPTION
Fixes #238 

Tested with the following curves_list:
'bike1l1cpa:p256_bike1l1cpa:bike1l1fo:p256_bike1l1fo:frodo640aes:p256_frodo640aes:frodo640shake:p256_frodo640shake:hqc128_1_cca2:p256_hqc128_1_cca2:kyber512:p256_kyber512:kyber90s512:p256_kyber90s512:ntru_hps2048509:p256_ntru_hps2048509:lightsaber:p256_lightsaber:sidhp434:p256_sidhp434:sidhp503:p256_sidhp503:sikep434:p256_sikep434:sikep503:p256_sikep503:bike1l3cpa:p384_bike1l3cpa:bike1l3fo:p384_bike1l3fo:frodo976aes:p384_frodo976aes:frodo976shake:p384_frodo976shake:hqc192_1_cca2:p384_hqc192_1_cca2:hqc192_2_cca2:p384_hqc192_2_cca2:kyber768:p384_kyber768:kyber90s768:p384_kyber90s768:ntru_hps2048677:p384_ntru_hps2048677:ntru_hrss701:p384_ntru_hrss701:saber:p384_saber:sidhp610:p384_sidhp610:sikep610:p384_sikep610:frodo1344aes:p521_frodo1344aes:frodo1344shake:p521_frodo1344shake:hqc256_1_cca2:p521_hqc256_1_cca2:hqc256_2_cca2:p521_hqc256_2_cca2:hqc256_3_cca2:p521_hqc256_3_cca2:kyber1024:p521_kyber1024:kyber90s1024:p521_kyber90s1024:ntru_hps4096821:p521_ntru_hps4096821:firesaber:p521_firesaber:sidhp751:p521_sidhp751:sikep751:p521_sikep751:P-256'

Test results:
Before:
```
./apps/openssl s_server -cert p256_dilithium2_CA.crt -key p256_dilithium2_CA.key -groups "bike1l1cpa:p256_bike1l1cpa:bike1l1fo:p256_bike1l1fo:frodo640aes:p256_frodo640aes:frodo640shake:p256_frodo640shake:hqc128_1_cca2:p256_hqc128_1_cca2:kyber512:p256_kyber512:kyber90s512:p256_kyber90s512:ntru_hps2048509:p256_ntru_hps2048509:lightsaber:p256_lightsaber:sidhp434:p256_sidhp434:sidhp503:p256_sidhp503:sikep434:p256_sikep434:sikep503:p256_sikep503:bike1l3cpa:p384_bike1l3cpa:bike1l3fo:p384_bike1l3fo:frodo976aes:p384_frodo976aes:frodo976shake:p384_frodo976shake:hqc192_1_cca2:p384_hqc192_1_cca2:hqc192_2_cca2:p384_hqc192_2_cca2:kyber768:p384_kyber768:kyber90s768:p384_kyber90s768:ntru_hps2048677:p384_ntru_hps2048677:ntru_hrss701:p384_ntru_hrss701:saber:p384_saber:sidhp610:p384_sidhp610:sikep610:p384_sikep610:frodo1344aes:p521_frodo1344aes:frodo1344shake:p521_frodo1344shake:hqc256_1_cca2:p521_hqc256_1_cca2:hqc256_2_cca2:p521_hqc256_2_cca2:hqc256_3_cca2:p521_hqc256_3_cca2:kyber1024:p521_kyber1024:kyber90s1024:p521_kyber90s1024:ntru_hps4096821:p521_ntru_hps4096821:firesaber:p521_firesaber:sidhp751:p521_sidhp751:sikep751:p521_sikep751:P-256"
Error with command: "-groups bike1l1cpa:p256_bike1l1cpa:bike1l1fo:p256_bike1l1fo:frodo640aes:p256_frodo640aes:frodo640shake:p256_frodo640shake:hqc128_1_cca2:p256_hqc128_1_cca2:kyber512:p256_kyber512:kyber90s512:p256_kyber90s512:ntru_hps2048509:p256_ntru_hps2048509:lightsaber:p256_lightsaber:sidhp434:p256_sidhp434:sidhp503:p256_sidhp503:sikep434:p256_sikep434:sikep503:p256_sikep503:bike1l3cpa:p384_bike1l3cpa:bike1l3fo:p384_bike1l3fo:frodo976aes:p384_frodo976aes:frodo976shake:p384_frodo976shake:hqc192_1_cca2:p384_hqc192_1_cca2:hqc192_2_cca2:p384_hqc192_2_cca2:kyber768:p384_kyber768:kyber90s768:p384_kyber90s768:ntru_hps2048677:p384_ntru_hps2048677:ntru_hrss701:p384_ntru_hrss701:saber:p384_saber:sidhp610:p384_sidhp610:sikep610:p384_sikep610:frodo1344aes:p521_frodo1344aes:frodo1344shake:p521_frodo1344shake:hqc256_1_cca2:p521_hqc256_1_cca2:hqc256_2_cca2:p521_hqc256_2_cca2:hqc256_3_cca2:p521_hqc256_3_cca2:kyber1024:p521_kyber1024:kyber90s1024:p521_kyber90s1024:ntru_hps4096821:p521_ntru_hps4096821:firesaber:p521_firesaber:sidhp751:p521_sidhp751:sikep751:p521_sikep751:P-256"
```

After:
```
./apps/openssl s_server -cert p256_dilithium2_CA.crt -key p256_dilithium2_CA.key -groups "bike1l1cpa:p256_bike1l1cpa:bike1l1fo:p256_bike1l1fo:frodo640aes:p256_frodo640aes:frodo640shake:p256_frodo640shake:hqc128_1_cca2:p256_hqc128_1_cca2:kyber512:p256_kyber512:kyber90s512:p256_kyber90s512:ntru_hps2048509:p256_ntru_hps2048509:lightsaber:p256_lightsaber:sidhp434:p256_sidhp434:sidhp503:p256_sidhp503:sikep434:p256_sikep434:sikep503:p256_sikep503:bike1l3cpa:p384_bike1l3cpa:bike1l3fo:p384_bike1l3fo:frodo976aes:p384_frodo976aes:frodo976shake:p384_frodo976shake:hqc192_1_cca2:p384_hqc192_1_cca2:hqc192_2_cca2:p384_hqc192_2_cca2:kyber768:p384_kyber768:kyber90s768:p384_kyber90s768:ntru_hps2048677:p384_ntru_hps2048677:ntru_hrss701:p384_ntru_hrss701:saber:p384_saber:sidhp610:p384_sidhp610:sikep610:p384_sikep610:frodo1344aes:p521_frodo1344aes:frodo1344shake:p521_frodo1344shake:hqc256_1_cca2:p521_hqc256_1_cca2:hqc256_2_cca2:p521_hqc256_2_cca2:hqc256_3_cca2:p521_hqc256_3_cca2:kyber1024:p521_kyber1024:kyber90s1024:p521_kyber90s1024:ntru_hps4096821:p521_ntru_hps4096821:firesaber:p521_firesaber:sidhp751:p521_sidhp751:sikep751:p521_sikep751:P-256"
Using default temp DH parameters
ACCEPT

```