### PR TITLE
Revert "openssl: Add count of liboqs pq and hybrid curves to MAX_CURVES_LIST"

### DIFF
--- a/ssl/t1_lib.c
+++ b/ssl/t1_lib.c
@@ -625,9 +625,7 @@ int tls1_set_groups(uint16_t **pext, size_t *pextlen,
     return 1;
 }
 
-# define MAX_CURVELIST   (OSSL_NELEM(nid_list) + \
-		          OSSL_NELEM(oqs_nid_list) + \
-			  OSSL_NELEM(oqs_hybrid_nid_list))
+# define MAX_CURVELIST   OSSL_NELEM(nid_list)
 
 typedef struct {
     size_t nidcnt;


### PR DESCRIPTION
Reverts open-quantum-safe/openssl#239. Experiencing failures, re-testing the branch...