### PR TITLE
Fix error in evp.h with -Werror=strict-prototypes

### DIFF
--- a/apps/speed.c
+++ b/apps/speed.c
@@ -102,13 +102,11 @@
 #ifndef OPENSSL_NO_OQSKEM
 # include <oqs/oqs.h>
 extern const char *OQSKEM_options(void);
-extern int* get_oqssl_kem_nids(); 
 #endif
 #include <openssl/modes.h>
 #ifndef OPENSSL_NO_OQSSIG
 # include <oqs/oqs.h>
 extern const char *OQSSIG_options(void);
-extern int* get_oqssl_sig_nids(); 
 extern int oqs_size(const EVP_PKEY *pkey);
 #endif
 #include <openssl/modes.h>

--- a/include/openssl/evp.h
+++ b/include/openssl/evp.h
@@ -102,8 +102,8 @@
 const char *OQSKEM_options(void);
 const char *OQSSIG_options(void);
 int oqs_size(const EVP_PKEY *pkey);
-int* get_oqssl_sig_nids();
-int* get_oqssl_kem_nids();
+int* get_oqssl_sig_nids(void);
+int* get_oqssl_kem_nids(void);
 char* get_oqs_alg_name(int openssl_nid);
 
 


### PR DESCRIPTION
Prototypes for get_oqssl_sig_nids() and get_oqssl_kem_nids trigger an error when -Werror=strict-prototypes is enabled in gcc.

This change adds void to the argument list to fix building with this setting enabled.
