### PR TITLE
BoringSSL now picks up OpenSSL-generated certificates in interop test.

### DIFF
--- a/oqs-interop-test/common.py
+++ b/oqs-interop-test/common.py
@@ -97,13 +97,15 @@ def gen_openssl_keys(ossl, sig_alg, test_artifacts_dir, filename_prefix):
                 shutil.copyfileobj(in_file, out_file)
 
 def start_server(client_type, test_artifacts_dir, sig_alg, worker_id):
+    gen_openssl_keys(OSSL, sig_alg, test_artifacts_dir, worker_id)
+
     if client_type == "ossl":
         server_command = [BSSL, 'server',
                                 '-accept', '0',
-                                '-sig-alg', sig_alg,
+                                '-cert', os.path.join(test_artifacts_dir, '{}_{}_srv.crt'.format(worker_id, sig_alg)),
+                                '-key', os.path.join(test_artifacts_dir, '{}_{}_srv.key'.format(worker_id, sig_alg)),
                                 '-loop']
     elif client_type == "bssl":
-        gen_openssl_keys(OSSL, sig_alg, test_artifacts_dir, worker_id)
         server_command = [OSSL, 's_server',
                                 '-cert', os.path.join(test_artifacts_dir, '{}_{}_srv.crt'.format(worker_id, sig_alg)),
                                 '-key', os.path.join(test_artifacts_dir, '{}_{}_srv.key'.format(worker_id, sig_alg)),

--- a/oqs-interop-test/test_full.py
+++ b/oqs-interop-test/test_full.py
@@ -29,7 +29,7 @@ def test_kex_sig_pair(kex_name, parametrized_sig_server, bssl_alg_to_id, client_
             kex_full_name = "{} hybrid".format(kex_name)
         else:
             kex_full_name = kex_name
-        if (not "Server Temp Key: {}".format(kex_full_name) in client_output) or (not "issuer=C = US, O = BoringSSL" in client_output):
+        if (not "Server Temp Key: {}".format(kex_full_name) in client_output) or (not "Peer signature type:" in client_output) or (not "Server certificate" in client_output):
             print(client_output)
             assert False
 


### PR DESCRIPTION
This is to avoid bugs like https://github.com/open-quantum-safe/boringssl/pull/45 in the future.