### PR TITLE
Remove expensive build from CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,14 +132,15 @@ jobs:
                  --header "Content-Type: application/json" \
                  -d '{ "branch": "main", "parameters": { "new_openssl_commit": true } }' \
                  https://circleci.com/api/v2/project/gh/open-quantum-safe/oqs-demos/pipeline
-      - run:
-          name: Trigger profiling CI
-          command: |
-            curl -u ${BUILD_TRIGGER_TOKEN}: \
-                 -X POST \
-                 --header "Content-Type: application/json" \
-                 -d '{ "branch": "main", "parameters": { "new_openssl_commit": true } }' \
-                 https://circleci.com/api/v2/project/gh/open-quantum-safe/profiling/pipeline
+      # don't trigger for now as it's too expensive
+      #- run:
+      #    name: Trigger profiling CI
+      #    command: |
+      #      curl -u ${BUILD_TRIGGER_TOKEN}: \
+      #           -X POST \
+      #           --header "Content-Type: application/json" \
+      #           -d '{ "branch": "main", "parameters": { "new_openssl_commit": true } }' \
+      #           https://circleci.com/api/v2/project/gh/open-quantum-safe/profiling/pipeline
 
 workflows:
   version: 2.1

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ For example, since `dilithium2` claims L1 security, the hybrids `rsa3072_dilithi
 
 ## Quickstart
 
-The steps below have been confirmed to work on macOS 10.14 (with clang 10.0.0), Ubuntu 18.04.1 (with gcc-7) and should work on more recent versions of these operating systems/compilers. They have also been confirmed to work on Windows 10 with Visual Studio 2019.
+The steps below have been confirmed to work on macOS 10.14 (with clang 10.0.0), Ubuntu 18.04.1 (with gcc-7) and should work on more recent versions of these operating systems/compilers. They have also been confirmed to work on Windows 10 with Visual Studio 2019. All commands below are just examples and might also be used and work differently as per the respective packages' documentations.
 
 ### Building
 


### PR DESCRIPTION
- Don't trigger profiling build automatically
- Be explicit on sample command documentation (fix pertaining to #279)

- [x] documentation is added or updated
