### PR TITLE
Improved signing support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2.1
 
-require_testapproval: &require_testapproval
-  requires:
-    - testapproval
-
 parameters:
   run_downstream_tests:
     type: boolean
@@ -34,7 +30,7 @@ jobs:
       TESTSET:
         description: "OQS test set."
         type: string
-        default: oqs-test/test_tls_basic.py
+        default: oqs-test/test_tls_basic.py oqs-test/test_dgst.py
     docker:
       - image: openquantumsafe/ci-ubuntu-focal-x86_64:latest
 # Re-enable iff docker enforces rate limitations without auth:
@@ -75,7 +71,7 @@ jobs:
       TESTSET:
         description: "OQS test set."
         type: string
-        default: oqs-test/test_tls_basic.py
+        default: oqs-test/test_tls_basic.py oqs-test/test_dgst.py
     steps:
       - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
       - run:
@@ -164,24 +160,29 @@ workflows:
           name: macOS-shared_oqs-shared_ossl
           LIBOQS_SHARED: true
           OPENSSL_SHARED: true
-      - testapproval:
+      - cond-testapproval:
           requires:
             - ubuntu-static_oqs-static_ossl
+          when:
+            equal: [ false , << pipeline.parameters.run_downstream_tests >> ]
           type: approval
       - macOS:
-          <<: *require_testapproval
           name: macOS-static_oqs-static_ossl
-          TESTSET: oqs-test/test_tls_full.py oqs-test/test_cms.py oqs-test/test_speed.py
+          requires: 
+            - cond-testapproval
+          TESTSET: oqs-test/test_tls_full.py oqs-test/test_cms.py oqs-test/test_speed.py oqs-test/test_dgst.py
       - ubuntu_focal:
-          <<: *require_testapproval
           name: ubuntu-shared_oqs-shared_ossl
+          requires: 
+            - cond-testapproval
           context: openquantumsafe
           LIBOQS_SHARED: true
           OPENSSL_SHARED: true
-          TESTSET: oqs-test/test_tls_full.py oqs-test/test_cms.py oqs-test/test_speed.py
+          TESTSET: oqs-test/test_tls_full.py oqs-test/test_cms.py oqs-test/test_speed.py oqs-test/test_dgst.py
       - ubuntu_boringssl_interop:
-          <<: *require_testapproval
           name: boringssl-interop
+          requires: 
+            - cond-testapproval
           context: openquantumsafe
   on-main-branch:
     when:

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ This command can be used to verify (and extract the contents) of the CMS file re
 
 The contents of `inputfile` and the resultant `signeddatafile` should be the same.
 
+Also supported are general signing operations using the standard [OpenSSL dgst](https://www.openssl.org/docs/man1.1.1/man1/dgst.html) commands using QSC public/private keys of [any of the supported signature algorithms](#authentication). Example command using the same file notation used above:
+
+        echo TestDataToSign | apps/openssl dgst -sha256 -sign <SIG>_srv.key -out signature
+
 #### Performance testing
 
 ##### TLS end-to-end testing

--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -1647,17 +1647,27 @@ static int pkey_oqs_digestverify(EVP_MD_CTX *ctx, const unsigned char *sig,
 
 static int pkey_oqs_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
 {
+    OQS_KEY *oqs_key = (OQS_KEY*) EVP_PKEY_CTX_get0_pkey(ctx)->pkey.ptr;
+
     switch (type) {
     case EVP_PKEY_CTRL_MD:
         /* NULL allowed as digest */
-        if (p2 == NULL)
+        if (p2 == NULL) {
             return 1;
-        /* accept SHA512 as digest for CMS */
-        if (*(int*)p2 == NID_sha512) {
-               return 1;
-        }
-        ECerr(EC_F_PKEY_OQS_CTRL, EC_R_WRONG_DIGEST);
-        return 0;
+	}
+
+	if (oqs_key->digest == NULL) { // allocate fitting digest engine
+        	if ((oqs_key->digest = EVP_MD_CTX_create()) == NULL) {
+           		return 0;
+		}
+
+	        if (EVP_DigestInit_ex(oqs_key->digest, EVP_get_digestbynid(*(int*)p2), NULL) <= 0) {
+           		return 0;
+        	}
+		
+	}
+	return 1; // accept any digest
+
 
     case EVP_PKEY_CTRL_DIGESTINIT:
         return 1;
@@ -1677,7 +1687,8 @@ static int pkey_oqs_sign(EVP_PKEY_CTX *ctx, unsigned char *sig,
                                size_t *siglen, const unsigned char *tbs,
                                size_t tbslen)
 {
-   return 1;
+   printf("oqs sign without digest auto fail\n");
+   return 0;
 }
 
 static int oqs_int_update(EVP_MD_CTX *ctx, const void *data, size_t count)
@@ -1685,13 +1696,13 @@ static int oqs_int_update(EVP_MD_CTX *ctx, const void *data, size_t count)
     OQS_KEY *oqs_key = (OQS_KEY*) EVP_MD_CTX_pkey_ctx(ctx)->pkey->pkey.ptr;
 
     if (oqs_key->digest == NULL) {
-        if ((oqs_key->digest = EVP_MD_CTX_create()) == NULL) {
-           return 0;
-        }
+       	if ((oqs_key->digest = EVP_MD_CTX_create()) == NULL) {
+       		return 0;
+	}
 
         if (EVP_DigestInit_ex(oqs_key->digest, EVP_sha512(), NULL) <= 0) {
-           return 0;
-        }
+       		return 0;
+       	}
     }
 
     if(EVP_DigestUpdate(oqs_key->digest, data, count)<=0) {
@@ -1713,21 +1724,20 @@ static int pkey_oqs_signctx(EVP_PKEY_CTX *ctx, unsigned char *sig, size_t *sigle
     unsigned char* tbs = NULL;
     unsigned int tbslen = 0;
 
-
     if (sig != NULL) {
-       tbslen = 512/8; // as per https://tools.ietf.org/id/draft-ietf-lamps-cms-shakes-08.html
-       // Finalize SHAKE:
-       if (oqs_key->digest == NULL) {
-         return 0;
-       }
+	// support any digest requested:
+	tbslen = EVP_MD_CTX_size(oqs_key->digest);
+	if (oqs_key->digest == NULL) {
+		return 0;
+	}
 
-       if((tbs = (unsigned char *)OPENSSL_malloc(tbslen)) == NULL) {
-         return 0;
-       }
+	if((tbs = (unsigned char *)OPENSSL_malloc(tbslen)) == NULL) {
+		return 0;
+	}
 
-       if(EVP_DigestFinal(oqs_key->digest, tbs, &tbslen) <= 0) {
-         return 0;
-       }
+	if(EVP_DigestFinal(oqs_key->digest, tbs, &tbslen) <= 0) {
+		return 0;
+	}
 
     }
     int ret = pkey_oqs_digestsign(mctx, sig, siglen, tbs, tbslen);
@@ -1756,7 +1766,8 @@ static int pkey_oqs_verify_init(EVP_PKEY_CTX *ctx) {
 static int pkey_oqs_verify(EVP_PKEY_CTX *ctx,
                    const unsigned char *sig, size_t siglen,
                    const unsigned char *tbs, size_t tbslen) {
-   return 1;
+	printf("oqs verify auto fail without digest\n");
+	return 0;
 }
 static int pkey_oqs_verifyctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx) {
 
@@ -1768,13 +1779,52 @@ static int pkey_oqs_verifyctx_init(EVP_PKEY_CTX *ctx, EVP_MD_CTX *mctx) {
 
 static int pkey_oqs_verifyctx(EVP_PKEY_CTX *ctx, const unsigned char *sig, int siglen,
                       EVP_MD_CTX *mctx) {
-   return 1;
+    OQS_KEY *oqs_key = (OQS_KEY*) EVP_MD_CTX_pkey_ctx(mctx)->pkey->pkey.ptr;
+    unsigned char* tbs = NULL;
+    unsigned int tbslen = 0;
+
+    if (sig != NULL) {
+       tbslen = 512/8; // as per https://tools.ietf.org/id/draft-ietf-lamps-cms-shakes-08.html
+       // Finalize SHAKE:
+       if (oqs_key->digest == NULL) {
+         return 0;
+       }
+
+       if((tbs = (unsigned char *)OPENSSL_malloc(tbslen)) == NULL) {
+         return 0;
+       }
+
+       if(EVP_DigestFinal(oqs_key->digest, tbs, &tbslen) <= 0) {
+         return 0;
+       }
+
+    }
+    int ret = pkey_oqs_digestverify(mctx, sig, siglen, tbs, tbslen); 
+    if (sig != NULL) { // cleanup only if it's not the empty setup call
+       OPENSSL_free(tbs);
+       EVP_MD_CTX_destroy(oqs_key->digest);
+       oqs_key->digest = NULL;
+    }
+    if (ret <= 0) {
+    }
+    else {
+       EVP_MD_CTX_set_flags(mctx, EVP_MD_CTX_FLAG_FINALISE); // don't go around again...
+    }
+
+   return ret;
 }
+
+static int pkey_oqs_copy(EVP_PKEY_CTX *dst, EVP_PKEY_CTX *src)
+{
+    // nothing specific needed, but EVP depends on its presence
+    return 1;
+}
+
 
 #define DEFINE_OQS_EVP_PKEY_METHOD(ALG, NID_ALG)    \
 const EVP_PKEY_METHOD ALG##_pkey_meth = {           \
     NID_ALG, EVP_PKEY_FLAG_SIGCTX_CUSTOM,           \
-    0, 0, 0, 0, 0, 0,                               \
+    0, pkey_oqs_copy, 0, 0, 0, 0,                   \
     pkey_oqs_keygen,                                \
     pkey_oqs_sign_init, pkey_oqs_sign,              \
     pkey_oqs_verify_init, pkey_oqs_verify,          \

--- a/oqs-test/test_dgst.py
+++ b/oqs-test/test_dgst.py
@@ -32,7 +32,7 @@ def test_sigverify(ossl, ossl_config, test_artifacts_dir, sig_name, worker_id):
     dgst_list = dgst_algs(dgsts_out)
     # now pick a random digest algorithm; for EC and RSA only accept a SHA[1|2]*
     test_dgst = dgst_list[random.randint(0, len(dgst_list)-1)]
-    while (sig_name.startswith("ec") or sig_name.startswith("rsa")) and not ("sha1" in test_dgst or "sha2" in test_dgst):
+    while (sig_name.startswith("ec") or sig_name.startswith("rsa")) and not (test_dgst.startswith("-sha1") or test_dgst.startswith("-sha2")):
        test_dgst = dgst_list[random.randint(0, len(dgst_list)-1)]
 
     # do sign/verify with the picked digest

--- a/oqs-test/test_dgst.py
+++ b/oqs-test/test_dgst.py
@@ -1,0 +1,51 @@
+import common
+import pytest
+import sys
+import os
+import random
+
+input_msg = "[OpenSSL](https://openssl.org/) is an open-source implementation of the TLS protocol and various cryptographic algorithms ([View the original README](https://github.com/open-quantum-safe/openssl/blob/OQS-OpenSSL_1_1_1-stable/README).)\nOQS-OpenSSL_1_1_1\t is a fork of OpenSSL 1.1.1 that adds quantum-safe key exchange and authentication algorithms using [liboqs](https://github.com/open-quantum-safe/liboqs) for prototyping and evaluation purposes. This fork is not endorsed by the OpenSSL project."
+
+# return a list of permissible digest algorithm names from -list output:
+def dgst_algs(alg_list):
+   algs = []
+   alg_list = alg_list.replace("\n", " ")
+   idx=alg_list.find("-")
+   while idx > 0:
+      sidx = alg_list.find(" ",idx+1)
+      if sidx < 0:
+          print("No space found. Weird.")
+          return algs
+      else:
+          algs.append(alg_list[idx:sidx])
+          alg_list = alg_list[sidx+1:]
+      idx=alg_list.find("-")
+   return algs
+
+
+@pytest.mark.parametrize('sig_name', common.signatures)
+def test_sigverify(ossl, ossl_config, test_artifacts_dir, sig_name, worker_id):
+    common.gen_keys(ossl, ossl_config, sig_name, test_artifacts_dir, worker_id)
+
+    # determine available digest algorithms
+    dgsts_out = common.run_subprocess([ossl, 'dgst', '-list'])
+    dgst_list = dgst_algs(dgsts_out)
+    # now pick a random digest algorithm; for EC and RSA only accept a SHA[1|2]*
+    test_dgst = dgst_list[random.randint(0, len(dgst_list)-1)]
+    while (sig_name.startswith("ec") or sig_name.startswith("rsa")) and not ("sha1" in test_dgst or "sha2" in test_dgst):
+       test_dgst = dgst_list[random.randint(0, len(dgst_list)-1)]
+
+    # do sign/verify with the picked digest
+    sign_out = common.run_subprocess([ossl, 'dgst', test_dgst, '-sign',
+                                                    os.path.join(test_artifacts_dir, '{}_{}_srv.key'.format(worker_id, sig_name)),
+                                                    '-out', os.path.join(test_artifacts_dir, '{}_{}_srv.signature'.format(worker_id, sig_name))],
+                                      input=input_msg.encode())
+    verify_out = common.run_subprocess([ossl, 'dgst', test_dgst, '-verify',
+                                  os.path.join(test_artifacts_dir, '{}_{}_srv.pubk'.format(worker_id, sig_name)),
+                                  '-signature', os.path.join(test_artifacts_dir, '{}_{}_srv.signature'.format(worker_id, sig_name))],
+                                      input=input_msg.encode())
+    assert "Verified OK" in verify_out
+
+if __name__ == "__main__":
+    import sys
+    pytest.main(sys.argv)


### PR DESCRIPTION
Fixes #295 adding support for any digest algorithm; SHA512 remains default if nothing else is specified.
Also removes manual CI approval from upstream-initiated builds.

- [x] documentation is added or updated
- [x] tests are added or updated
