### PR TITLE
fix liboqs.so.version install

### DIFF
--- a/Configurations/unix-Makefile.tmpl
+++ b/Configurations/unix-Makefile.tmpl
@@ -790,10 +790,11 @@ endif
 ifneq (,$(wildcard $(OQSLIBDIR)/liboqs.so.0*))
 	@set -e; for i in $(OQSLIBDIR)/liboqs.so.0.*; do \
 		fn=`basename $$i`; \
+		sn=`basename $(OQSLIBDIR)/liboqs.so.?`; \
 		$(ECHO) "install $(OQSLIBDIR)/$$fn $(DESTDIR)$(libdir)"; \
-		$(ECHO) "cd $(DESTDIR)$(libdir) && ln -sf $$fn liboqs.so && ln -sf $$fn liboqs.so.0 && cd -"; \
+		$(ECHO) "cd $(DESTDIR)$(libdir) && ln -sf $$fn liboqs.so && ln -sf $$fn $$sn && cd -"; \
 		install $(OQSLIBDIR)/$$fn $(DESTDIR)$(libdir); \
-		cd $(DESTDIR)$(libdir) && ln -sf $$fn liboqs.so && ln -sf $$fn liboqs.so.0 && cd -; \
+		cd $(DESTDIR)$(libdir) && ln -sf $$fn liboqs.so && ln -sf $$fn $$sn && cd -; \
 	done
 endif
 


### PR DESCRIPTION
Fixes failing downstream tests: This PR now ensures shared-lib versions of `liboqs` with its [changing SOVERSION number](https://github.com/open-quantum-safe/liboqs/blob/3cf9849cc43545ad7fdeb3092a90f94ff1881680/src/CMakeLists.txt#L94)  are properly installed (when `liboqs` gets installed alongside `openssl`).


