### PR TITLE
Added support for EVP_md_null() in pkey_oqs_ctrl. 

### DIFF
--- a/crypto/ec/oqs_meth.c
+++ b/crypto/ec/oqs_meth.c
@@ -1587,7 +1587,7 @@ static int pkey_oqs_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2)
     switch (type) {
     case EVP_PKEY_CTRL_MD:
         /* NULL allowed as digest */
-        if (p2 == NULL) {
+        if (p2 == NULL || (const EVP_MD *)p2 == EVP_md_null()) {
             return 1;
 	}
 


### PR DESCRIPTION
When using the PKEY methods for signing or verifying, you can specify the use of a digest algorithm as an intermediary or nothing. To align with other PKEY methods, this pull request adds the support for using the EVP_md_null() value alongside the NULL value for the p2 parameter in the pkey_oqs_ctrl function (see ecx_meth.c for an example).

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x ] documentation is added or updated
- [ ] tests are added or updated
