### PR TITLE
WIP: Enable access to the curves and certificate type

### DIFF
--- a/doc/man3/SSL_get_used_group_id.pod
+++ b/doc/man3/SSL_get_used_group_id.pod
@@ -1,0 +1,46 @@
+=pod
+
+=head1 NAME
+
+SSL_get_used_group_id, SSL_get_used_group_nid, SSL_get_used_sigalg_nid - get information
+about the curve that was used for the key agreement of the current TLS session establishment
+and about the signature algorithm that was used to sign the certificate of the peer.
+
+=head1 SYNOPSIS
+
+ #include <openssl/ssl.h>
+
+ long SSL_get_used_group_id(SSL *ssl);
+ long SSL_get_used_group_nid(SSL *ssl);
+ long SSL_get_used_sigalg_nid(SSL *ssl);
+
+=head1 DESCRIPTION
+
+SSL_get_used_group_id() returns the ID of the group of the curve that was used for the key agreement of the current TLS session establishment.
+
+SSL_get_used_group_nid() returns the name of the group of the curve that was used for the key agreement of the current TLS session establishment.
+
+SSL_get_used_sigalg_nid() returns the name of the signature algorithm (and hash if applicable) that was used to sign the certificate of the peer.
+
+=head1 RETURN VALUES
+
+All these functions return ids on success and 0 otherwise.
+
+=head1 NOTES
+
+This function is implemented as a macro.
+
+=head1 SEE ALSO
+
+L<ssl(7)>
+
+=head1 COPYRIGHT
+
+Copyright 2017-2018 The OpenSSL Project Authors. All Rights Reserved.
+
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+L<https://www.openssl.org/source/license.html>.
+
+=cut

--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -1312,6 +1312,9 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_GET_OQS_KEM_CURVE_ID           134
 # define SSL_CTRL_GET_VERIFY_CERT_STORE          137
 # define SSL_CTRL_GET_CHAIN_CERT_STORE           138
+# define SSL_CTRL_GET_USED_GROUP_ID              139
+# define SSL_CTRL_GET_USED_GROUP_NID             140
+# define SSL_CTRL_GET_USED_SIGALG_NID            141
 # define SSL_CERT_SET_FIRST                      1
 # define SSL_CERT_SET_NEXT                       2
 # define SSL_CERT_SET_SERVER                     3
@@ -1470,6 +1473,12 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
         SSL_ctrl(s, SSL_CTRL_GET_MAX_PROTO_VERSION, 0, NULL)
 #define SSL_get_oqs_kem_curve_id(s) \
         SSL_ctrl(s, SSL_CTRL_GET_OQS_KEM_CURVE_ID, 0, NULL)
+#define SSL_get_used_group_id(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_USED_GROUP_ID, 0, NULL)
+#define SSL_get_used_group_nid(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_USED_GROUP_NID, 0, NULL)
+#define SSL_get_used_sigalg_nid(s) \
+        SSL_ctrl(s, SSL_CTRL_GET_USED_SIGALG_NID, 0, NULL)
 
 /* Backwards compatibility, original 1.1.0 names */
 # define SSL_CTRL_GET_SERVER_TMP_KEY \
@@ -1485,6 +1494,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_CTRL_SET_CURVES           SSL_CTRL_SET_GROUPS
 # define SSL_CTRL_SET_CURVES_LIST      SSL_CTRL_SET_GROUPS_LIST
 # define SSL_CTRL_GET_SHARED_CURVE     SSL_CTRL_GET_SHARED_GROUP
+# define SSL_CTRL_GET_USED_CURVE_ID    SSL_CTRL_GET_USED_GROUP_ID
+# define SSL_CTRL_GET_USED_CURVE_NID   SSL_CTRL_GET_USED_GROUP_NID
 
 # define SSL_get1_curves               SSL_get1_groups
 # define SSL_CTX_set1_curves           SSL_CTX_set1_groups
@@ -1492,7 +1503,8 @@ DECLARE_PEM_rw(SSL_SESSION, SSL_SESSION)
 # define SSL_set1_curves               SSL_set1_groups
 # define SSL_set1_curves_list          SSL_set1_groups_list
 # define SSL_get_shared_curve          SSL_get_shared_group
-
+# define SSL_get_used_curve_id         SSL_get_used_group_id
+# define SSL_get_used_curve_nid        SSL_get_used_group_nid
 
 # if OPENSSL_API_COMPAT < 0x10100000L
 /* Provide some compatibility macros for removed functionality. */

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3746,14 +3746,14 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_USED_GROUP_ID:
         {
           if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server || s->session == NULL) return 0;
+          if (s->server == 0|| s->session == NULL) return 0;
           return s->s3->tmp.oqs_kem_curve_id ? s->s3->tmp.oqs_kem_curve_id : s->s3->group_id;
         }
     case SSL_CTRL_GET_USED_GROUP_NID:
         {
           if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server || s->session == NULL) return 0;
-          TLS_GROUP_INFO *tls_group_info =
+          if (s->server == 0|| s->session == NULL) return 0;
+          const TLS_GROUP_INFO *tls_group_info =
             tls1_group_id_lookup(s->s3->tmp.oqs_kem_curve_id ?
                                  s->s3->tmp.oqs_kem_curve_id : s->s3->group_id);
           return tls_group_info == NULL ? 0 : tls_group_info->nid;
@@ -3761,7 +3761,8 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
     case SSL_CTRL_GET_USED_SIGALG_NID:
         {
           if (s == NULL || s->s3 == NULL) return 0;
-          if (s->server || s->session == NULL) return 0;
+          if (s->session == NULL) return 0;
+          if (s->s3->tmp.peer_sigalg == NULL) return 0;
           if (s->s3->tmp.peer_sigalg->sig == EVP_PKEY_EC)
              return s->s3->tmp.peer_sigalg->sigandhash;
           return s->s3->tmp.peer_sigalg->sig;

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3743,6 +3743,29 @@ long ssl3_ctrl(SSL *s, int cmd, long larg, void *parg)
             return s->s3->tmp.oqs_kem_curve_id;
           }
         }
+    case SSL_CTRL_GET_USED_GROUP_ID:
+        {
+          if (s == NULL || s->s3 == NULL) return 0;
+          if (s->server || s->session == NULL) return 0;
+          return s->s3->tmp.oqs_kem_curve_id ? s->s3->tmp.oqs_kem_curve_id : s->s3->group_id;
+        }
+    case SSL_CTRL_GET_USED_GROUP_NID:
+        {
+          if (s == NULL || s->s3 == NULL) return 0;
+          if (s->server || s->session == NULL) return 0;
+          TLS_GROUP_INFO *tls_group_info =
+            tls1_group_id_lookup(s->s3->tmp.oqs_kem_curve_id ?
+                                 s->s3->tmp.oqs_kem_curve_id : s->s3->group_id);
+          return tls_group_info == NULL ? 0 : tls_group_info->nid;
+        }
+    case SSL_CTRL_GET_USED_SIGALG_NID:
+        {
+          if (s == NULL || s->s3 == NULL) return 0;
+          if (s->server || s->session == NULL) return 0;
+          if (s->s3->tmp.peer_sigalg->sig == EVP_PKEY_EC)
+             return s->s3->tmp.peer_sigalg->sigandhash;
+          return s->s3->tmp.peer_sigalg->sig;
+        }
     default:
         break;
     }

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -21,7 +21,6 @@
 
 #include "ssltestlib.h"
 #include "testutil.h"
-#include "testutil/output.h"
 #include "internal/nelem.h"
 #include "../ssl/ssl_local.h"
 
@@ -5723,6 +5722,51 @@ static int test_ssl_get_shared_ciphers(int tst)
     return testresult;
 }
 
+static int test_ssl_get_used_group(int tst)
+{
+    SSL_CTX *cctx = NULL, *sctx = NULL;
+    SSL *clientssl = NULL, *serverssl = NULL;
+    int testresult = 0;
+
+    if (!TEST_true(create_ssl_ctx_pair(TLS_server_method(),
+                                       TLS_client_method(),
+                                       TLS1_VERSION,
+                                       TLS_MAX_VERSION,
+                                       &sctx, &cctx, cert, privkey)))
+        goto end;
+
+    if (!TEST_true(SSL_CTX_set_cipher_list(cctx, "AES128-SHA"))
+            || !TEST_true(SSL_CTX_set_ciphersuites(cctx, "TLS_AES_256_GCM_SHA384"))
+            || !TEST_true(SSL_CTX_set_cipher_list(sctx, "AES256-SHA"))
+            || !TEST_true(SSL_CTX_set_ciphersuites(sctx, "TLS_AES_256_GCM_SHA384")))
+         goto end;
+
+
+    if (!TEST_true(create_ssl_objects(sctx, cctx, &serverssl, &clientssl,
+                                             NULL, NULL))
+            || !TEST_true(create_ssl_connection(serverssl, clientssl,
+                                                SSL_ERROR_NONE)))
+        goto end;
+
+    if (!TEST_long_eq(SSL_get_used_group_id(serverssl), 29)
+            || !TEST_long_eq(SSL_get_used_group_nid(serverssl), 1034)
+            || !TEST_long_eq(SSL_get_used_sigalg_nid(serverssl), 0)
+            || !TEST_long_eq(SSL_get_used_group_id(clientssl), 0)
+            || !TEST_long_eq(SSL_get_used_group_nid(clientssl), 0)
+            || !TEST_long_eq(SSL_get_used_sigalg_nid(clientssl), 912))
+        goto end;
+
+    testresult = 1;
+
+ end:
+    SSL_free(serverssl);
+    SSL_free(clientssl);
+    SSL_CTX_free(sctx);
+    SSL_CTX_free(cctx);
+
+    return testresult;
+}
+
 static const char *appdata = "Hello World";
 static int gen_tick_called, dec_tick_called, tick_key_cb_called;
 static int tick_key_renew = 0;
@@ -7250,6 +7294,7 @@ int setup_tests(void)
     ADD_ALL_TESTS(test_info_callback, 6);
     ADD_ALL_TESTS(test_ssl_pending, 2);
     ADD_ALL_TESTS(test_ssl_get_shared_ciphers, OSSL_NELEM(shared_ciphers_data));
+    ADD_ALL_TESTS(test_ssl_get_used_group, 1);
     ADD_ALL_TESTS(test_ticket_callbacks, 12);
     ADD_ALL_TESTS(test_shutdown, 7);
     ADD_ALL_TESTS(test_cert_cb, 6);


### PR DESCRIPTION
This PR changes enable access to the curves and certificate type used in TLSv1.3 handshakes.

This equivalent to access to the ciphers used in the TLS session. The benefit is that monitoring/logging can not only report the protocol and ciphers, but also the curve and certificate type used for a TLSv1.3 connection on the client side. In particular, an user can verify that a quantum-safe-crypto curve and certificate was used.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
