### PR TITLE
Updated generate.yml to support liboqs 0.8.0 algorithm changes

### DIFF
--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -218,74 +218,6 @@ kems:
     nid_hybrid: '0x2F43'
     oqs_alg: 'OQS_KEM_alg_bike_l5'
   -
-    family: 'CRYSTALS-Kyber'
-    name_group: 'kyber90s512'
-    extra_nids:
-      old:
-        - implementation_version: NIST Round 2 submission
-          nist-round: 2
-          nid: '0x0229'
-        - implementation_version: NIST Round 2 submission
-          nist-round: 2
-          hybrid_group: secp256_r1
-          nid: '0x2F29'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          nid: '0x023E'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          hybrid_group: secp256_r1
-          nid: '0x2F3E'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          hybrid_group: x25519
-          nid: '0x2FA9'
-    oqs_alg: 'OQS_KEM_alg_kyber_512_90s'
-  -
-    family: 'CRYSTALS-Kyber'
-    name_group: 'kyber90s768'
-    extra_nids:
-      old:
-        - implementation_version: NIST Round 2 submission
-          nist-round: 2
-          nid: '0x022A'
-        - implementation_version: NIST Round 2 submission
-          nist-round: 2
-          hybrid_group: secp384_r1
-          nid: '0x2F2A'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          nid: '0x023F'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          hybrid_group: secp384_r1
-          nid: '0x2F3F'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          hybrid_group: x448
-          nid: '0x2FAA'
-    oqs_alg: 'OQS_KEM_alg_kyber_768_90s'
-  -
-    family: 'CRYSTALS-Kyber'
-    name_group: 'kyber90s1024'
-    extra_nids:
-      old:
-        - implementation_version: NIST Round 2 submission
-          nist-round: 2
-          nid: '0x022B'
-        - implementation_version: NIST Round 2 submission
-          nist-round: 2
-          hybrid_group: secp521_r1
-          nid: '0x2F2B'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          nid: '0x0240'
-        - implementation_version: NIST Round 3 submission
-          nist-round: 3
-          hybrid_group: secp521_r1
-          nid: '0x2F40'
-    oqs_alg: 'OQS_KEM_alg_kyber_1024_90s'
-  -
     family: 'HQC'
     name_group: 'hqc128'
     nid: '0x022C'
@@ -398,55 +330,6 @@ sigs:
                     'pretty_name': 'ECDSA p521',
                     'oid': '1.3.9999.2.7.4',
                     'code_point': '0xfea6'}]
-      -
-        name: 'dilithium2_aes'
-        pretty_name: 'Dilithium2_AES'
-        oqs_meth: 'OQS_SIG_alg_dilithium_2_aes'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.6.1.4.1.2.267.11.4.4'
-              code_point: '0xfea7'
-              supported_encodings: ['draft-uni-qsckeys-dilithium-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.2.11.1',
-                          'code_point': '0xfea8'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.2.11.2',
-                          'code_point': '0xfea9'}]
-      -
-        name: 'dilithium3_aes'
-        pretty_name: 'Dilithium3_AES'
-        oqs_meth: 'OQS_SIG_alg_dilithium_3_aes'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.6.1.4.1.2.267.11.6.5'
-              code_point: '0xfeaa'
-              supported_encodings: ['draft-uni-qsckeys-dilithium-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.2.11.3',
-                          'code_point': '0xfeab'}]
-      -
-        name: 'dilithium5_aes'
-        pretty_name: 'Dilithium5_AES'
-        oqs_meth: 'OQS_SIG_alg_dilithium_5_aes'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.6.1.4.1.2.267.11.8.7'
-              code_point: '0xfeac'
-              supported_encodings: ['draft-uni-qsckeys-dilithium-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.2.11.4',
-                          'code_point': '0xfead'}]
   -
     # iso (1)
     # identified-organization (3)
@@ -507,226 +390,8 @@ sigs:
                           'oid': '1.3.9999.3.5',
                           'code_point': '0xfe0f'}]
   -
-    family: 'SPHINCS-Haraka'
-    variants:
-      -
-        name: 'sphincsharaka128frobust'
-        pretty_name: 'SPHINCS+-Haraka-128f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.1.1'
-              code_point: '0xfe42'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.1.2',
-                          'code_point': '0xfe43'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.1.3',
-                          'code_point': '0xfe44'}]
-      -
-        name: 'sphincsharaka128fsimple'
-        pretty_name: 'SPHINCS+-Haraka-128f-simple'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128f_simple'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.1.4'
-              code_point: '0xfe45'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.1.5',
-                          'code_point': '0xfe46'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.1.6',
-                          'code_point': '0xfe47'}]
-      -
-        name: 'sphincsharaka128srobust'
-        pretty_name: 'SPHINCS+-Haraka-128s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.1.7'
-              code_point: '0xfe48'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.1.8',
-                          'code_point': '0xfe49'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.1.9',
-                          'code_point': '0xfe4a'}]
-      -
-        name: 'sphincsharaka128ssimple'
-        pretty_name: 'SPHINCS+-Haraka-128s-simple'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_128s_simple'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.1.10'
-              code_point: '0xfe4b'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.1.11',
-                          'code_point': '0xfe4c'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.1.12',
-                          'code_point': '0xfe4d'}]
-      -
-        name: 'sphincsharaka192frobust'
-        pretty_name: 'SPHINCS+-Haraka-192f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.2.1'
-              code_point: '0xfe4e'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.2.2',
-                          'code_point': '0xfe4f'}]
-      -
-        name: 'sphincsharaka192fsimple'
-        pretty_name: 'SPHINCS+-Haraka-192f-simple'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192f_simple'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.2.3'
-              code_point: '0xfe50'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.2.4',
-                          'code_point': '0xfe51'}]
-      -
-        name: 'sphincsharaka192srobust'
-        pretty_name: 'SPHINCS+-Haraka-192s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.2.5'
-              code_point: '0xfe52'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.2.6',
-                          'code_point': '0xfe53'}]
-      -
-        name: 'sphincsharaka192ssimple'
-        pretty_name: 'SPHINCS+-Haraka-192s-simple'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_192s_simple'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.2.7'
-              code_point: '0xfe54'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.2.8',
-                          'code_point': '0xfe55'}]
-      -
-        name: 'sphincsharaka256frobust'
-        pretty_name: 'SPHINCS+-Haraka-256f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.3.1'
-              code_point: '0xfe56'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.3.2',
-                          'code_point': '0xfe57'}]
-      -
-        name: 'sphincsharaka256fsimple'
-        pretty_name: 'SPHINCS+-Haraka-256f-simple'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256f_simple'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.3.3'
-              code_point: '0xfe58'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.3.4',
-                          'code_point': '0xfe59'}]
-      -
-        name: 'sphincsharaka256srobust'
-        pretty_name: 'SPHINCS+-Haraka-256s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.3.5'
-              code_point: '0xfe5a'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.3.6',
-                          'code_point': '0xfe5b'}]
-      -
-        name: 'sphincsharaka256ssimple'
-        pretty_name: 'SPHINCS+-Haraka-256s-simple'
-        oqs_meth: 'OQS_SIG_alg_sphincs_haraka_256s_simple'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.3.7'
-              code_point: '0xfe5c'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.3.8',
-                          'code_point': '0xfe5d'}]
-  -
     family: 'SPHINCS-SHA2'
     variants:
-      -
-        name: 'sphincssha26128frobust'
-        pretty_name: 'SPHINCS+-SHA256-128f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.4.1'
-              code_point: '0xfe5e'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.4.2',
-                          'code_point': '0xfe5f'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.4.3',
-                          'code_point': '0xfe60'}]
       -
         name: 'sphincssha2128fsimple'
         pretty_name: 'SPHINCS+-SHA2-128f-simple'
@@ -759,25 +424,6 @@ sigs:
                           'oid': '1.3.9999.6.4.6',
                           'code_point': '0xfe63'}]
       -
-        name: 'sphincssha256128srobust'
-        pretty_name: 'SPHINCS+-SHA256-128s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_128s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.4.7'
-              code_point: '0xfe64'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.4.8',
-                          'code_point': '0xfe65'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.4.9',
-                          'code_point': '0xfe66'}]
-      -
         name: 'sphincssha2128ssimple'
         pretty_name: 'SPHINCS+-SHA2-128s-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_sha2_128s_simple'
@@ -809,21 +455,6 @@ sigs:
                           'oid': '1.3.9999.6.4.12',
                           'code_point': '0xfe69'}]
       -
-        name: 'sphincssha256192frobust'
-        pretty_name: 'SPHINCS+-SHA256-192f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.5.1'
-              code_point: '0xfe6a'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.5.2',
-                          'code_point': '0xfe6b'}]
-      -
         name: 'sphincssha2192fsimple'
         pretty_name: 'SPHINCS+-SHA2-192f-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_sha2_192f_simple'
@@ -846,21 +477,7 @@ sigs:
                           'pretty_name': 'ECDSA p384',
                           'oid': '1.3.9999.6.5.4',
                           'code_point': '0xfe6d'}]
-      -
-        name: 'sphincssha256192srobust'
-        pretty_name: 'SPHINCS+-SHA256-192s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_192s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.5.5'
-              code_point: '0xfe6e'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.5.6',
-                          'code_point': '0xfe6f'}]
+
       -
         name: 'sphincssha2192ssimple'
         pretty_name: 'SPHINCS+-SHA2-192s-simple'
@@ -885,21 +502,6 @@ sigs:
                           'oid': '1.3.9999.6.5.8',
                           'code_point': '0xfe71'}]
       -
-        name: 'sphincssha256256frobust'
-        pretty_name: 'SPHINCS+-SHA256-256f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.6.1'
-              code_point: '0xfe72'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.6.2',
-                          'code_point': '0xfe73'}]
-      -
         name: 'sphincssha2256fsimple'
         pretty_name: 'SPHINCS+-SHA2-256f-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_sha2_256f_simple'
@@ -922,21 +524,6 @@ sigs:
                           'pretty_name': 'ECDSA p521',
                           'oid': '1.3.9999.6.6.4',
                           'code_point': '0xfe75'}]
-      -
-        name: 'sphincssha256256srobust'
-        pretty_name: 'SPHINCS+-SHA256-256s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_sha256_256s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.6.5'
-              code_point: '0xfe76'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.6.6',
-                          'code_point': '0xfe77'}]
       -
         name: 'sphincssha2256ssimple'
         pretty_name: 'SPHINCS+-SHA2-256s-simple'
@@ -963,25 +550,6 @@ sigs:
   -
     family: 'SPHINCS-SHAKE'
     variants:
-      -
-        name: 'sphincsshake256128frobust'
-        pretty_name: 'SPHINCS+-SHAKE256-128f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.7.1'
-              code_point: '0xfe7a'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.7.2',
-                          'code_point': '0xfe7b'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.7.3',
-                          'code_point': '0xfe7c'}]
       -
         name: 'sphincsshake128fsimple'
         pretty_name: 'SPHINCS+-SHAKE-128f-simple'
@@ -1014,25 +582,6 @@ sigs:
                           'oid': '1.3.9999.6.7.6',
                           'code_point': '0xfe7f'}]
       -
-        name: 'sphincsshake256128srobust'
-        pretty_name: 'SPHINCS+-SHAKE256-128s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_128s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.7.7'
-              code_point: '0xfe80'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p256',
-                          'pretty_name': 'ECDSA p256',
-                          'oid': '1.3.9999.6.7.8',
-                          'code_point': '0xfe81'},
-                         {'name': 'rsa3072',
-                          'pretty_name': 'RSA3072',
-                          'oid': '1.3.9999.6.7.9',
-                          'code_point': '0xfe82'}]
-      -
         name: 'sphincsshake128ssimple'
         pretty_name: 'SPHINCS+-SHAKE-128s-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_shake_128s_simple'
@@ -1064,21 +613,7 @@ sigs:
                           'oid': '1.3.9999.6.7.12',
                           'code_point': '0xfe85'}]
       -
-        name: 'sphincsshake256192frobust'
-        pretty_name: 'SPHINCS+-SHAKE256-192f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.8.1'
-              code_point: '0xfe86'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.8.2',
-                          'code_point': '0xfe87'}]
-      -
+
         name: 'sphincsshake192fsimple'
         pretty_name: 'SPHINCS+-SHAKE-192f-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_shake_192f_simple'
@@ -1102,21 +637,7 @@ sigs:
                           'oid': '1.3.9999.6.8.4',
                           'code_point': '0xfe89'}]
       -
-        name: 'sphincsshake256192srobust'
-        pretty_name: 'SPHINCS+-SHAKE256-192s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_192s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.8.5'
-              code_point: '0xfe8a'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p384',
-                          'pretty_name': 'ECDSA p384',
-                          'oid': '1.3.9999.6.8.6',
-                          'code_point': '0xfe8b'}]
-      -
+
         name: 'sphincsshake192ssimple'
         pretty_name: 'SPHINCS+-SHAKE-192s-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_shake_192s_simple'
@@ -1139,21 +660,6 @@ sigs:
                           'pretty_name': 'ECDSA p384',
                           'oid': '1.3.9999.6.8.8',
                           'code_point': '0xfe8d'}]
-      -
-        name: 'sphincsshake256256frobust'
-        pretty_name: 'SPHINCS+-SHAKE256-256f-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256f_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.9.1'
-              code_point: '0xfe8e'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.9.2',
-                          'code_point': '0xfe8f'}]
       -
         name: 'sphincsshake256fsimple'
         pretty_name: 'SPHINCS+-SHAKE-256f-simple'
@@ -1178,21 +684,6 @@ sigs:
                           'oid': '1.3.9999.6.9.4',
                           'code_point': '0xfe91'}]
       -
-        name: 'sphincsshake256256srobust'
-        pretty_name: 'SPHINCS+-SHAKE256-256s-robust'
-        oqs_meth: 'OQS_SIG_alg_sphincs_shake256_256s_robust'
-        extra_nids:
-          old:
-            - implementation_version: NIST Round 3 submission
-              nist-round: 3
-              oid: '1.3.9999.6.9.5'
-              code_point: '0xfe92'
-              supported_encodings: ['draft-uni-qsckeys-sphincsplus-00/sk-pk']
-              mix_with: [{'name': 'p521',
-                          'pretty_name': 'ECDSA p521',
-                          'oid': '1.3.9999.6.9.6',
-                          'code_point': '0xfe93'}]
-      -
         name: 'sphincsshake256ssimple'
         pretty_name: 'SPHINCS+-SHAKE-256s-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_shake_256s_simple'
@@ -1215,5 +706,3 @@ sigs:
                           'pretty_name': 'ECDSA p521',
                           'oid': '1.3.9999.6.9.8',
                           'code_point': '0xfe95'}]
-
-

--- a/oqs-template/generate.yml
+++ b/oqs-template/generate.yml
@@ -477,7 +477,6 @@ sigs:
                           'pretty_name': 'ECDSA p384',
                           'oid': '1.3.9999.6.5.4',
                           'code_point': '0xfe6d'}]
-
       -
         name: 'sphincssha2192ssimple'
         pretty_name: 'SPHINCS+-SHA2-192s-simple'
@@ -613,7 +612,6 @@ sigs:
                           'oid': '1.3.9999.6.7.12',
                           'code_point': '0xfe85'}]
       -
-
         name: 'sphincsshake192fsimple'
         pretty_name: 'SPHINCS+-SHAKE-192f-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_shake_192f_simple'
@@ -637,7 +635,6 @@ sigs:
                           'oid': '1.3.9999.6.8.4',
                           'code_point': '0xfe89'}]
       -
-
         name: 'sphincsshake192ssimple'
         pretty_name: 'SPHINCS+-SHAKE-192s-simple'
         oqs_meth: 'OQS_SIG_alg_sphincs_shake_192s_simple'


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING

Other than that, provide a description above this comment if there isn't one already

If this fixes a github issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ x] documentation is added or updated
- [ x] tests are added or updated

Fixes to oqs-template/generate.yml that were causing "nist-security levels not found" errors in oqs-template/generate.py. Certain default algorithms included in the file are no longer valid for liboqs builds that use the latest verison. 

The following algorithms were removed:

- Kyber90s variants
- SPHINCS+ Haraka variants
- SPHINCS+ robust variants
- Dilithium AES variants


