### PR TITLE
Code point documentation update

### DIFF
--- a/oqs-template/generate_oid_nid_table.py
+++ b/oqs-template/generate_oid_nid_table.py
@@ -68,6 +68,7 @@ def gen_sig_table(oqslibdocdir):
                               hybrid['oid']])
 
   with open(os.path.join('oqs-template', 'oqs-sig-info.md'), mode='w', encoding='utf-8') as f:
+    f.write("## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-sig-info.md")
     f.write(tabulate(table, tablefmt="pipe", headers="firstrow"))
   print("Written oqs-sig-info.md")
 
@@ -142,6 +143,7 @@ def gen_kem_table(oqslibdocdir):
   table = [table_header] + table
 
   with open(os.path.join('oqs-template', 'oqs-kem-info.md'), mode='w', encoding='utf-8') as f:
+    f.write("## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md")
     f.write(tabulate(table, tablefmt="pipe", headers="firstrow"))
     f.write("\n")
   print("Written oqs-kem-info.md")

--- a/oqs-template/generate_oid_nid_table.py
+++ b/oqs-template/generate_oid_nid_table.py
@@ -68,7 +68,7 @@ def gen_sig_table(oqslibdocdir):
                               hybrid['oid']])
 
   with open(os.path.join('oqs-template', 'oqs-sig-info.md'), mode='w', encoding='utf-8') as f:
-    f.write("## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-sig-info.md")
+    f.write("## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-sig-info.md\n\n")
     f.write(tabulate(table, tablefmt="pipe", headers="firstrow"))
   print("Written oqs-sig-info.md")
 
@@ -143,7 +143,7 @@ def gen_kem_table(oqslibdocdir):
   table = [table_header] + table
 
   with open(os.path.join('oqs-template', 'oqs-kem-info.md'), mode='w', encoding='utf-8') as f:
-    f.write("## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md")
+    f.write("## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md\n\n")
     f.write(tabulate(table, tablefmt="pipe", headers="firstrow"))
     f.write("\n")
   print("Written oqs-kem-info.md")

--- a/oqs-template/oqs-kem-info.md
+++ b/oqs-template/oqs-kem-info.md
@@ -1,3 +1,5 @@
+## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-kem-info.md
+
 | Family         | Implementation Version   | Variant        |   NIST round |   Claimed NIST Level | Code Point   | Hybrid Elliptic Curve (if any)   |
 |:---------------|:-------------------------|:---------------|-------------:|---------------------:|:-------------|:---------------------------------|
 | BIKE           | 5.1                      | bikel1         |            4 |                    1 | 0x0241       |                                  |

--- a/oqs-template/oqs-sig-info.md
+++ b/oqs-template/oqs-sig-info.md
@@ -1,5 +1,4 @@
-## Note: As oqs-openssl111 is phased out, please rely on the new iteration of th
-is information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-sig-info.md
+## Note: As oqs-openssl111 is phased out, please rely on the new iteration of this information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-sig-info.md
 
 | Algorithm                                      | Implementation Version                        |   NIST round |   Claimed NIST Level | Code Point   | OID                     |
 |:-----------------------------------------------|:----------------------------------------------|-------------:|---------------------:|:-------------|:------------------------|

--- a/oqs-template/oqs-sig-info.md
+++ b/oqs-template/oqs-sig-info.md
@@ -1,3 +1,6 @@
+## Note: As oqs-openssl111 is phased out, please rely on the new iteration of th
+is information at https://github.com/open-quantum-safe/oqs-provider/blob/main/oqs-template/oqs-sig-info.md
+
 | Algorithm                                      | Implementation Version                        |   NIST round |   Claimed NIST Level | Code Point   | OID                     |
 |:-----------------------------------------------|:----------------------------------------------|-------------:|---------------------:|:-------------|:------------------------|
 | dilithium2                                     | 3.1                                           |            3 |                    2 | 0xfea0       | 1.3.6.1.4.1.2.267.7.4.4 |


### PR DESCRIPTION
Point interop documentation to oqs-provider. Also resolves the concern raised in https://github.com/open-quantum-safe/openssl/pull/456#pullrequestreview-1481299292 and the interop question by @crockeea 

- [yes] documentation is added or updated
- [no] tests are added or updated
